### PR TITLE
feat(api): add REST routes for contacts CRUD

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dbPath = path.resolve(__dirname, '..', 'data', 'contacts.db');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  fs.rmSync(dbPath, { force: true });
+  const { createApp } = await import('./server.js');
+  server = createApp();
+
+  await new Promise((resolve) => {
+    server.listen(0, () => {
+      const address = server.address();
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  fs.rmSync(dbPath, { force: true });
+});
+
+test('health endpoint returns 200', async () => {
+  const response = await fetch(`${baseUrl}/api/health`);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), { status: 'ok' });
+});
+
+test('contacts CRUD flow works end-to-end', async () => {
+  const createResponse = await fetch(`${baseUrl}/api/contacts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      phone: '123-456-7890',
+    }),
+  });
+
+  assert.equal(createResponse.status, 201);
+  assert.equal(createResponse.headers.get('content-type'), 'application/json');
+
+  const createdContact = await createResponse.json();
+  assert.equal(createdContact.name, 'Ada Lovelace');
+  assert.equal(createdContact.email, 'ada@example.com');
+  assert.equal(createdContact.phone, '123-456-7890');
+  assert.ok(createdContact.id);
+
+  const listResponse = await fetch(`${baseUrl}/api/contacts`);
+  assert.equal(listResponse.status, 200);
+  assert.equal(listResponse.headers.get('content-type'), 'application/json');
+
+  const contacts = await listResponse.json();
+  assert.ok(contacts.some((contact) => contact.id === createdContact.id));
+
+  const getResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  assert.equal(getResponse.status, 200);
+  assert.equal(getResponse.headers.get('content-type'), 'application/json');
+  assert.equal((await getResponse.json()).id, createdContact.id);
+
+  const updateResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Ada King',
+      email: 'ada.king@example.com',
+      phone: '555-0000',
+    }),
+  });
+
+  assert.equal(updateResponse.status, 200);
+  assert.equal(updateResponse.headers.get('content-type'), 'application/json');
+
+  const updatedContact = await updateResponse.json();
+  assert.equal(updatedContact.name, 'Ada King');
+  assert.equal(updatedContact.email, 'ada.king@example.com');
+  assert.equal(updatedContact.phone, '555-0000');
+
+  const deleteResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+    method: 'DELETE',
+  });
+
+  assert.equal(deleteResponse.status, 204);
+  assert.equal(deleteResponse.headers.get('content-type'), 'application/json');
+  assert.equal(await deleteResponse.text(), '');
+
+  const missingResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  assert.equal(missingResponse.status, 404);
+  assert.equal(missingResponse.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await missingResponse.json(), { error: 'Not Found' });
+});
+
+test('unsupported methods return 405', async () => {
+  const response = await fetch(`${baseUrl}/api/contacts`, {
+    method: 'PATCH',
+  });
+
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), { error: 'Method Not Allowed' });
+});

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,114 @@
+import { create, deleteById, getAll, getById, update } from './db.js';
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(payload === undefined ? '' : JSON.stringify(payload));
+}
+
+function sendMethodNotAllowed(res) {
+  sendJson(res, 405, { error: 'Method Not Allowed' });
+}
+
+function sendNotFound(res) {
+  sendJson(res, 404, { error: 'Not Found' });
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  const rawBody = Buffer.concat(chunks).toString('utf8').trim();
+
+  if (!rawBody) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(rawBody);
+  } catch {
+    throw new Error('Invalid JSON body');
+  }
+}
+
+function parseContactId(pathname) {
+  const match = pathname.match(/^\/api\/contacts\/(\d+)$/);
+  return match ? Number(match[1]) : null;
+}
+
+export async function router(req, res) {
+  const method = req.method ?? 'GET';
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const { pathname } = url;
+
+  try {
+    if (pathname === '/api/health') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, { status: 'ok' });
+    }
+
+    if (pathname === '/api/contacts') {
+      if (method === 'GET') {
+        return sendJson(res, 200, getAll());
+      }
+
+      if (method === 'POST') {
+        const body = await readJsonBody(req);
+        const contact = create(body);
+        return sendJson(res, 201, contact);
+      }
+
+      return sendMethodNotAllowed(res);
+    }
+
+    const contactId = parseContactId(pathname);
+
+    if (contactId !== null) {
+      if (method === 'GET') {
+        const contact = getById(contactId);
+        return contact ? sendJson(res, 200, contact) : sendNotFound(res);
+      }
+
+      if (method === 'PUT') {
+        const body = await readJsonBody(req);
+        const contact = update(contactId, body);
+        return contact ? sendJson(res, 200, contact) : sendNotFound(res);
+      }
+
+      if (method === 'DELETE') {
+        const deleted = deleteById(contactId);
+
+        if (!deleted) {
+          return sendNotFound(res);
+        }
+
+        res.writeHead(204, { 'Content-Type': 'application/json' });
+        return res.end();
+      }
+
+      return sendMethodNotAllowed(res);
+    }
+
+    return sendNotFound(res);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Invalid JSON body') {
+      return sendJson(res, 400, { error: error.message });
+    }
+
+    if (error instanceof Error && error.message === 'name is required') {
+      return sendJson(res, 400, { error: error.message });
+    }
+
+    console.error(error);
+    return sendJson(res, 500, { error: 'Internal Server Error' });
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,14 +1,35 @@
 import http from 'node:http';
+import { fileURLToPath } from 'node:url';
 
-const PORT = process.env.PORT || 3456;
+import { router } from './router.js';
 
-const server = http.createServer((req, res) => {
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('oc-test-app scaffold');
-});
+const PORT = Number(process.env.PORT || 3456);
 
-server.listen(PORT, () => {
-  console.log(`Listening on :${PORT}`);
-});
+function createApp() {
+  return http.createServer((req, res) => {
+    Promise.resolve(router(req, res)).catch((error) => {
+      console.error(error);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Internal Server Error' }));
+    });
+  });
+}
 
-export { server };
+const server = createApp();
+
+function startServer(port = PORT) {
+  return new Promise((resolve) => {
+    server.listen(port, () => {
+      console.log(`Listening on :${port}`);
+      resolve(server);
+    });
+  });
+}
+
+const isMainModule = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMainModule) {
+  startServer();
+}
+
+export { createApp, server, startServer };


### PR DESCRIPTION
## Summary
- add a raw Node HTTP router for contacts CRUD and health routes
- update the server entrypoint to use the router while preserving port 3456
- add API tests covering health, CRUD, and 405 handling

## Validation
- npm test
- node src/server.js + curl checks for /api/health, POST/GET /api/contacts, and 405 on PATCH /api/contacts