### PR TITLE
test(api): add node test coverage for contacts

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-test-app-'));
+const dbPath = path.join(tempDir, 'contacts.test.db');
+
+process.env.CONTACTS_DB_PATH = dbPath;
+
+const { createServer } = await import('./server.js');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  server = createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('API contact lifecycle works end-to-end', async () => {
+  const healthResponse = await fetch(`${baseUrl}/api/health`);
+  assert.equal(healthResponse.status, 200);
+  assert.deepEqual(await healthResponse.json(), { status: 'ok' });
+
+  const createPayload = {
+    name: 'Alice Example',
+    email: 'alice@example.com',
+    phone: '123-456-7890',
+  };
+
+  const createResponse = await fetch(`${baseUrl}/api/contacts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(createPayload),
+  });
+  assert.equal(createResponse.status, 201);
+
+  const createdContact = await createResponse.json();
+  assert.equal(createdContact.name, createPayload.name);
+  assert.equal(createdContact.email, createPayload.email);
+  assert.equal(createdContact.phone, createPayload.phone);
+  assert.equal(typeof createdContact.id, 'number');
+
+  const listResponse = await fetch(`${baseUrl}/api/contacts`);
+  assert.equal(listResponse.status, 200);
+
+  const listedContacts = await listResponse.json();
+  assert.ok(Array.isArray(listedContacts));
+  assert.ok(listedContacts.some((contact) => contact.id === createdContact.id && contact.name === createPayload.name));
+
+  const getResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  assert.equal(getResponse.status, 200);
+  assert.deepEqual(await getResponse.json(), createdContact);
+
+  const updatePayload = {
+    name: 'Alice Updated',
+    email: 'alice.updated@example.com',
+    phone: '999-555-1212',
+  };
+
+  const updateResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updatePayload),
+  });
+  assert.equal(updateResponse.status, 200);
+
+  const updatedContact = await updateResponse.json();
+  assert.equal(updatedContact.id, createdContact.id);
+  assert.equal(updatedContact.name, updatePayload.name);
+  assert.equal(updatedContact.email, updatePayload.email);
+  assert.equal(updatedContact.phone, updatePayload.phone);
+
+  const deleteResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+    method: 'DELETE',
+  });
+  assert.equal(deleteResponse.status, 204);
+  assert.equal(await deleteResponse.text(), '');
+
+  const missingResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  assert.equal(missingResponse.status, 404);
+  assert.deepEqual(await missingResponse.json(), { error: 'contact not found' });
+});

--- a/src/db.js
+++ b/src/db.js
@@ -5,10 +5,12 @@ import Database from 'better-sqlite3';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const dataDir = path.resolve(__dirname, '..', 'data');
-const dbPath = path.join(dataDir, 'contacts.db');
+const defaultDataDir = path.resolve(__dirname, '..', 'data');
+const configuredDbPath = process.env.CONTACTS_DB_PATH;
+const dbPath = configuredDbPath ?? path.join(defaultDataDir, 'contacts.db');
+const dbDir = path.dirname(dbPath);
 
-fs.mkdirSync(dataDir, { recursive: true });
+fs.mkdirSync(dbDir, { recursive: true });
 
 const db = new Database(dbPath);
 
@@ -52,6 +54,10 @@ const deleteStmt = db.prepare(`
   WHERE id = ?
 `);
 
+function normalizeOptionalText(value) {
+  return typeof value === 'string' ? value.trim() : value ?? null;
+}
+
 function normalizeContactInput({ name, email = null, phone = null } = {}) {
   const normalizedName = typeof name === 'string' ? name.trim() : '';
 
@@ -61,8 +67,8 @@ function normalizeContactInput({ name, email = null, phone = null } = {}) {
 
   return {
     name: normalizedName,
-    email: email ?? null,
-    phone: phone ?? null,
+    email: normalizeOptionalText(email),
+    phone: normalizeOptionalText(phone),
   };
 }
 
@@ -96,4 +102,3 @@ export function deleteById(id) {
   const result = deleteStmt.run(id);
   return result.changes > 0;
 }
-

--- a/src/server.js
+++ b/src/server.js
@@ -1,14 +1,109 @@
 import http from 'node:http';
+import { create, deleteById, getAll, getById, update } from './db.js';
 
-const PORT = process.env.PORT || 3456;
+const DEFAULT_PORT = 3456;
 
-const server = http.createServer((req, res) => {
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('oc-test-app scaffold');
-});
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
 
-server.listen(PORT, () => {
-  console.log(`Listening on :${PORT}`);
-});
+async function readJsonBody(req) {
+  const chunks = [];
 
-export { server };
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  const rawBody = Buffer.concat(chunks).toString('utf8');
+
+  if (!rawBody.trim()) {
+    return {};
+  }
+
+  return JSON.parse(rawBody);
+}
+
+async function requestHandler(req, res) {
+  const method = req.method ?? 'GET';
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const contactMatch = url.pathname.match(/^\/api\/contacts\/(\d+)$/);
+
+  try {
+    if (method === 'GET' && url.pathname === '/api/health') {
+      return sendJson(res, 200, { status: 'ok' });
+    }
+
+    if (method === 'GET' && url.pathname === '/api/contacts') {
+      return sendJson(res, 200, getAll());
+    }
+
+    if (contactMatch) {
+      const id = Number(contactMatch[1]);
+
+      if (method === 'GET') {
+        const contact = getById(id);
+        return contact
+          ? sendJson(res, 200, contact)
+          : sendJson(res, 404, { error: 'contact not found' });
+      }
+
+      if (method === 'PUT') {
+        const body = await readJsonBody(req);
+        const contact = update(id, body);
+        return contact
+          ? sendJson(res, 200, contact)
+          : sendJson(res, 404, { error: 'contact not found' });
+      }
+
+      if (method === 'DELETE') {
+        const deleted = deleteById(id);
+
+        if (!deleted) {
+          return sendJson(res, 404, { error: 'contact not found' });
+        }
+
+        res.writeHead(204);
+        return res.end();
+      }
+    }
+
+    if (method === 'POST' && url.pathname === '/api/contacts') {
+      const body = await readJsonBody(req);
+      const contact = create(body);
+      return sendJson(res, 201, contact);
+    }
+
+    return sendJson(res, 404, { error: 'not found' });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return sendJson(res, 400, { error: 'invalid JSON body' });
+    }
+
+    if (error instanceof Error && error.message === 'name is required') {
+      return sendJson(res, 400, { error: error.message });
+    }
+
+    console.error(error);
+    return sendJson(res, 500, { error: 'internal server error' });
+  }
+}
+
+export function createServer() {
+  return http.createServer((req, res) => {
+    void requestHandler(req, res);
+  });
+}
+
+export const server = createServer();
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const port = Number(process.env.PORT) || DEFAULT_PORT;
+  server.listen(port, () => {
+    console.log(`Listening on :${port}`);
+  });
+}


### PR DESCRIPTION
## Summary\n- add a Node built-in test runner API lifecycle test using a random-port server\n- make the SQLite DB path configurable so tests can use an isolated temp database\n- implement the missing REST endpoints required for the test suite on this branch\n\n## Testing\n- npm test\n- npm run typecheck