### PR TITLE
feat: add vanilla contact book frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OC Test App Contact Book</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f4f7fb;
+        color: #1f2937;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        padding: 32px 16px;
+        background: linear-gradient(180deg, #f8fbff 0%, #eef4fa 100%);
+      }
+
+      .app {
+        width: min(960px, 100%);
+        background: #ffffff;
+        border-radius: 18px;
+        box-shadow: 0 18px 60px rgba(15, 23, 42, 0.12);
+        padding: 32px;
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: clamp(1.75rem, 3vw, 2.4rem);
+      }
+
+      .subtitle {
+        margin: 0 0 24px;
+        color: #4b5563;
+      }
+
+      .status {
+        min-height: 24px;
+        margin-bottom: 16px;
+        color: #1d4ed8;
+        font-weight: 600;
+      }
+
+      .status.error {
+        color: #b91c1c;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: 320px 1fr;
+        gap: 24px;
+      }
+
+      .panel {
+        background: #f8fafc;
+        border: 1px solid #e5e7eb;
+        border-radius: 14px;
+        padding: 20px;
+      }
+
+      .panel h2 {
+        margin-top: 0;
+        font-size: 1.1rem;
+      }
+
+      form {
+        display: grid;
+        gap: 12px;
+      }
+
+      label {
+        font-size: 0.95rem;
+        font-weight: 600;
+      }
+
+      input {
+        width: 100%;
+        margin-top: 6px;
+        padding: 10px 12px;
+        border: 1px solid #cbd5e1;
+        border-radius: 10px;
+        font: inherit;
+        background: #fff;
+      }
+
+      button {
+        border: 0;
+        border-radius: 10px;
+        padding: 10px 14px;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+        transition: transform 0.05s ease, opacity 0.2s ease;
+      }
+
+      button:hover {
+        opacity: 0.92;
+      }
+
+      button:active {
+        transform: translateY(1px);
+      }
+
+      .primary {
+        background: #2563eb;
+        color: white;
+      }
+
+      .secondary {
+        background: #e5e7eb;
+        color: #111827;
+      }
+
+      .danger {
+        background: #ef4444;
+        color: white;
+      }
+
+      .table-wrap {
+        overflow-x: auto;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th, td {
+        text-align: left;
+        padding: 14px 12px;
+        border-bottom: 1px solid #e5e7eb;
+        vertical-align: top;
+      }
+
+      th {
+        color: #475569;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      td.actions {
+        width: 160px;
+      }
+
+      .actions-row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .empty {
+        padding: 24px 0;
+        color: #6b7280;
+      }
+
+      @media (max-width: 860px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+
+        .app {
+          padding: 22px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="app">
+      <h1>Contact Book</h1>
+      <p class="subtitle">Add, edit, and remove contacts with a simple vanilla JS interface.</p>
+      <div id="status" class="status" aria-live="polite"></div>
+
+      <section class="layout">
+        <aside class="panel">
+          <h2 id="form-title">Add Contact</h2>
+          <form id="contact-form">
+            <label>
+              Name
+              <input id="name" name="name" type="text" required maxlength="100" />
+            </label>
+            <label>
+              Email
+              <input id="email" name="email" type="email" maxlength="200" />
+            </label>
+            <label>
+              Phone
+              <input id="phone" name="phone" type="text" maxlength="50" />
+            </label>
+            <div class="actions-row">
+              <button type="submit" id="submit-button" class="primary">Add Contact</button>
+              <button type="button" id="cancel-button" class="secondary" hidden>Cancel</button>
+            </div>
+          </form>
+        </aside>
+
+        <section class="panel">
+          <h2>All Contacts</h2>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Phone</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="contacts-body"></tbody>
+            </table>
+          </div>
+          <p id="empty-state" class="empty" hidden>No contacts yet. Add one to get started.</p>
+        </section>
+      </section>
+    </main>
+
+    <script>
+      const form = document.getElementById('contact-form');
+      const formTitle = document.getElementById('form-title');
+      const submitButton = document.getElementById('submit-button');
+      const cancelButton = document.getElementById('cancel-button');
+      const statusEl = document.getElementById('status');
+      const contactsBody = document.getElementById('contacts-body');
+      const emptyState = document.getElementById('empty-state');
+      const nameInput = document.getElementById('name');
+      const emailInput = document.getElementById('email');
+      const phoneInput = document.getElementById('phone');
+
+      let editingId = null;
+
+      function escapeHtml(value) {
+        return String(value ?? '')
+          .replaceAll('&', '&amp;')
+          .replaceAll('<', '&lt;')
+          .replaceAll('>', '&gt;')
+          .replaceAll('"', '&quot;')
+          .replaceAll("'", '&#39;');
+      }
+
+      function setStatus(message, isError = false) {
+        statusEl.textContent = message;
+        statusEl.classList.toggle('error', isError);
+      }
+
+      function resetForm() {
+        editingId = null;
+        form.reset();
+        formTitle.textContent = 'Add Contact';
+        submitButton.textContent = 'Add Contact';
+        cancelButton.hidden = true;
+      }
+
+      function startEdit(contact) {
+        editingId = contact.id;
+        formTitle.textContent = 'Edit Contact';
+        submitButton.textContent = 'Save Changes';
+        cancelButton.hidden = false;
+        nameInput.value = contact.name || '';
+        emailInput.value = contact.email || '';
+        phoneInput.value = contact.phone || '';
+        nameInput.focus();
+        setStatus(`Editing ${contact.name}`);
+      }
+
+      function renderContacts(contacts) {
+        contactsBody.innerHTML = '';
+        emptyState.hidden = contacts.length > 0;
+
+        for (const contact of contacts) {
+          const row = document.createElement('tr');
+          row.innerHTML = `
+            <td>${escapeHtml(contact.name)}</td>
+            <td>${escapeHtml(contact.email || '—')}</td>
+            <td>${escapeHtml(contact.phone || '—')}</td>
+            <td class="actions">
+              <div class="actions-row">
+                <button type="button" class="secondary" data-action="edit">Edit</button>
+                <button type="button" class="danger" data-action="delete">Delete</button>
+              </div>
+            </td>
+          `;
+
+          row.querySelector('[data-action="edit"]').addEventListener('click', () => startEdit(contact));
+          row.querySelector('[data-action="delete"]').addEventListener('click', async () => {
+            const confirmed = window.confirm(`Delete ${contact.name}?`);
+            if (!confirmed) {
+              return;
+            }
+
+            try {
+              const response = await fetch(`/api/contacts/${contact.id}`, { method: 'DELETE' });
+              if (!response.ok) {
+                throw new Error('Failed to delete contact');
+              }
+              if (editingId === contact.id) {
+                resetForm();
+              }
+              setStatus(`Deleted ${contact.name}`);
+              await loadContacts();
+            } catch (error) {
+              setStatus(error.message, true);
+            }
+          });
+
+          contactsBody.appendChild(row);
+        }
+      }
+
+      async function loadContacts() {
+        try {
+          const response = await fetch('/api/contacts');
+          if (!response.ok) {
+            throw new Error('Failed to load contacts');
+          }
+          const contacts = await response.json();
+          renderContacts(contacts);
+        } catch (error) {
+          setStatus(error.message, true);
+        }
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const payload = {
+          name: nameInput.value,
+          email: emailInput.value,
+          phone: phoneInput.value,
+        };
+
+        const isEditing = editingId !== null;
+        const url = isEditing ? `/api/contacts/${editingId}` : '/api/contacts';
+        const method = isEditing ? 'PUT' : 'POST';
+
+        try {
+          const response = await fetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+
+          const data = response.status === 204 ? null : await response.json().catch(() => null);
+          if (!response.ok) {
+            throw new Error(data?.error || 'Request failed');
+          }
+
+          setStatus(isEditing ? `Updated ${data.name}` : `Added ${data.name}`);
+          resetForm();
+          await loadContacts();
+        } catch (error) {
+          setStatus(error.message, true);
+        }
+      });
+
+      cancelButton.addEventListener('click', () => {
+        resetForm();
+        setStatus('Edit cancelled');
+      });
+
+      resetForm();
+      loadContacts();
+    </script>
+  </body>
+</html>

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-test-app-'));
+process.env.CONTACTS_DB_PATH = path.join(tempDir, 'contacts.db');
+
+const { createServer } = await import('./server.js');
+
+test('contact API supports health and CRUD flows', async (t) => {
+  const server = createServer();
+
+  await new Promise((resolve) => server.listen(0, resolve));
+  t.after(() => server.close());
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const healthResponse = await fetch(`${baseUrl}/api/health`);
+  assert.equal(healthResponse.status, 200);
+  assert.deepEqual(await healthResponse.json(), { status: 'ok' });
+
+  const createResponse = await fetch(`${baseUrl}/api/contacts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      phone: '123-456',
+    }),
+  });
+  assert.equal(createResponse.status, 201);
+  const createdContact = await createResponse.json();
+  assert.equal(createdContact.name, 'Ada Lovelace');
+
+  const listResponse = await fetch(`${baseUrl}/api/contacts`);
+  assert.equal(listResponse.status, 200);
+  const contacts = await listResponse.json();
+  assert.ok(contacts.some((contact) => contact.id === createdContact.id && contact.name === 'Ada Lovelace'));
+
+  const getResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  assert.equal(getResponse.status, 200);
+  assert.equal((await getResponse.json()).email, 'ada@example.com');
+
+  const updateResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Ada Byron',
+      email: 'ada.byron@example.com',
+      phone: '555-0100',
+    }),
+  });
+  assert.equal(updateResponse.status, 200);
+  assert.equal((await updateResponse.json()).name, 'Ada Byron');
+
+  const deleteResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+    method: 'DELETE',
+  });
+  assert.equal(deleteResponse.status, 204);
+
+  const deletedResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  assert.equal(deletedResponse.status, 404);
+});
+
+
+test('non-api routes serve the frontend', async (t) => {
+  const server = createServer();
+
+  await new Promise((resolve) => server.listen(0, resolve));
+  t.after(() => server.close());
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/contacts`);
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get('content-type') || '', /text\/html/);
+  assert.match(await response.text(), /Contact Book/);
+});

--- a/src/db.js
+++ b/src/db.js
@@ -5,8 +5,9 @@ import Database from 'better-sqlite3';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const dataDir = path.resolve(__dirname, '..', 'data');
-const dbPath = path.join(dataDir, 'contacts.db');
+const defaultDataDir = path.resolve(__dirname, '..', 'data');
+const dbPath = process.env.CONTACTS_DB_PATH || path.join(defaultDataDir, 'contacts.db');
+const dataDir = path.dirname(dbPath);
 
 fs.mkdirSync(dataDir, { recursive: true });
 
@@ -52,6 +53,19 @@ const deleteStmt = db.prepare(`
   WHERE id = ?
 `);
 
+function normalizeOptionalText(value) {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    return String(value);
+  }
+
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
 function normalizeContactInput({ name, email = null, phone = null } = {}) {
   const normalizedName = typeof name === 'string' ? name.trim() : '';
 
@@ -61,8 +75,8 @@ function normalizeContactInput({ name, email = null, phone = null } = {}) {
 
   return {
     name: normalizedName,
-    email: email ?? null,
-    phone: phone ?? null,
+    email: normalizeOptionalText(email),
+    phone: normalizeOptionalText(phone),
   };
 }
 
@@ -96,4 +110,3 @@ export function deleteById(id) {
   const result = deleteStmt.run(id);
   return result.changes > 0;
 }
-

--- a/src/server.js
+++ b/src/server.js
@@ -1,14 +1,199 @@
+import fs from 'node:fs';
 import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { create, deleteById, getAll, getById, update } from './db.js';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const publicDir = path.resolve(__dirname, '..', 'public');
+const indexPath = path.join(publicDir, 'index.html');
 const PORT = process.env.PORT || 3456;
 
-const server = http.createServer((req, res) => {
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('oc-test-app scaffold');
-});
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml; charset=utf-8',
+  '.ico': 'image/x-icon',
+};
 
-server.listen(PORT, () => {
-  console.log(`Listening on :${PORT}`);
-});
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(data));
+}
 
-export { server };
+function sendEmpty(res, statusCode) {
+  res.writeHead(statusCode);
+  res.end();
+}
+
+function sendText(res, statusCode, message) {
+  res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end(message);
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+
+    req.on('data', (chunk) => {
+      body += chunk;
+
+      if (body.length > 1_000_000) {
+        reject(new Error('request body too large'));
+        req.destroy();
+      }
+    });
+
+    req.on('end', () => {
+      if (!body) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(body));
+      } catch {
+        reject(new Error('invalid json'));
+      }
+    });
+
+    req.on('error', reject);
+  });
+}
+
+function serveFile(res, filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (error, content) => {
+    if (error) {
+      sendText(res, 404, 'Not found');
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+}
+
+function serveStatic(req, res) {
+  const url = new URL(req.url, 'http://localhost');
+  const requestedPath = decodeURIComponent(url.pathname);
+
+  if (requestedPath === '/' || !path.extname(requestedPath)) {
+    serveFile(res, indexPath);
+    return;
+  }
+
+  const normalizedPath = path.normalize(requestedPath).replace(/^([.][.][/\\])+/, '');
+  const filePath = path.join(publicDir, normalizedPath);
+
+  if (!filePath.startsWith(publicDir)) {
+    sendText(res, 403, 'Forbidden');
+    return;
+  }
+
+  serveFile(res, filePath);
+}
+
+async function requestHandler(req, res) {
+  const url = new URL(req.url, 'http://localhost');
+  const { pathname } = url;
+
+  if (req.method === 'GET' && pathname === '/api/health') {
+    sendJson(res, 200, { status: 'ok' });
+    return;
+  }
+
+  if (req.method === 'GET' && pathname === '/api/contacts') {
+    sendJson(res, 200, getAll());
+    return;
+  }
+
+  const contactMatch = pathname.match(/^\/api\/contacts\/(\d+)$/);
+  if (contactMatch) {
+    const id = Number(contactMatch[1]);
+
+    if (req.method === 'GET') {
+      const contact = getById(id);
+      if (!contact) {
+        sendJson(res, 404, { error: 'Contact not found' });
+        return;
+      }
+
+      sendJson(res, 200, contact);
+      return;
+    }
+
+    if (req.method === 'PUT') {
+      try {
+        const payload = await readJsonBody(req);
+        const contact = update(id, payload);
+
+        if (!contact) {
+          sendJson(res, 404, { error: 'Contact not found' });
+          return;
+        }
+
+        sendJson(res, 200, contact);
+      } catch (error) {
+        sendJson(res, 400, { error: error.message });
+      }
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      const deleted = deleteById(id);
+      if (!deleted) {
+        sendJson(res, 404, { error: 'Contact not found' });
+        return;
+      }
+
+      sendEmpty(res, 204);
+      return;
+    }
+  }
+
+  if (req.method === 'POST' && pathname === '/api/contacts') {
+    try {
+      const payload = await readJsonBody(req);
+      const contact = create(payload);
+      sendJson(res, 201, contact);
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+    }
+    return;
+  }
+
+  if (!pathname.startsWith('/api/')) {
+    serveStatic(req, res);
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Not found' });
+}
+
+function createServer() {
+  return http.createServer((req, res) => {
+    requestHandler(req, res).catch((error) => {
+      sendJson(res, 500, { error: error.message || 'Internal server error' });
+    });
+  });
+}
+
+const server = createServer();
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  server.listen(PORT, () => {
+    console.log(`Listening on :${PORT}`);
+  });
+}
+
+export { createServer, server };


### PR DESCRIPTION
## Summary
- add a clean vanilla HTML/CSS/JS contact book UI under public/index.html
- implement raw Node HTTP API routing plus static file serving for non-API routes
- add node:test coverage for health, CRUD flow, and frontend route serving

## Validation
- npm test
- npm run typecheck
- manual smoke test against http://127.0.0.1:3456/ and /api/health