### PR TITLE
test(api): add API test suite using Node built-in test runner

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -10,19 +10,16 @@ const dbPath = path.resolve(__dirname, '..', 'data', 'contacts.db');
 
 let server;
 let baseUrl;
+let createdContact;
 
 test.before(async () => {
   fs.rmSync(dbPath, { force: true });
-  const { createApp } = await import('./server.js');
-  server = createApp();
 
-  await new Promise((resolve) => {
-    server.listen(0, () => {
-      const address = server.address();
-      baseUrl = `http://127.0.0.1:${address.port}`;
-      resolve();
-    });
-  });
+  const { startServer } = await import('./server.js');
+  server = await startServer(0);
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
 });
 
 test.after(async () => {
@@ -42,7 +39,7 @@ test.after(async () => {
   fs.rmSync(dbPath, { force: true });
 });
 
-test('health endpoint returns 200', async () => {
+test('health endpoint returns 200 with expected payload', async () => {
   const response = await fetch(`${baseUrl}/api/health`);
 
   assert.equal(response.status, 200);
@@ -50,8 +47,8 @@ test('health endpoint returns 200', async () => {
   assert.deepEqual(await response.json(), { status: 'ok' });
 });
 
-test('contacts CRUD flow works end-to-end', async () => {
-  const createResponse = await fetch(`${baseUrl}/api/contacts`, {
+test('create a contact via POST returns 201', async () => {
+  const response = await fetch(`${baseUrl}/api/contacts`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -61,28 +58,36 @@ test('contacts CRUD flow works end-to-end', async () => {
     }),
   });
 
-  assert.equal(createResponse.status, 201);
-  assert.equal(createResponse.headers.get('content-type'), 'application/json');
+  assert.equal(response.status, 201);
+  assert.equal(response.headers.get('content-type'), 'application/json');
 
-  const createdContact = await createResponse.json();
+  createdContact = await response.json();
   assert.equal(createdContact.name, 'Ada Lovelace');
   assert.equal(createdContact.email, 'ada@example.com');
   assert.equal(createdContact.phone, '123-456-7890');
   assert.ok(createdContact.id);
+});
 
-  const listResponse = await fetch(`${baseUrl}/api/contacts`);
-  assert.equal(listResponse.status, 200);
-  assert.equal(listResponse.headers.get('content-type'), 'application/json');
+test('list contacts includes the created contact', async () => {
+  const response = await fetch(`${baseUrl}/api/contacts`);
 
-  const contacts = await listResponse.json();
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+
+  const contacts = await response.json();
   assert.ok(contacts.some((contact) => contact.id === createdContact.id));
+});
 
-  const getResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
-  assert.equal(getResponse.status, 200);
-  assert.equal(getResponse.headers.get('content-type'), 'application/json');
-  assert.equal((await getResponse.json()).id, createdContact.id);
+test('get contact by ID returns 200 with correct data', async () => {
+  const response = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
 
-  const updateResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), createdContact);
+});
+
+test('update contact via PUT returns 200 with updated data', async () => {
+  const response = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -92,34 +97,29 @@ test('contacts CRUD flow works end-to-end', async () => {
     }),
   });
 
-  assert.equal(updateResponse.status, 200);
-  assert.equal(updateResponse.headers.get('content-type'), 'application/json');
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
 
-  const updatedContact = await updateResponse.json();
-  assert.equal(updatedContact.name, 'Ada King');
-  assert.equal(updatedContact.email, 'ada.king@example.com');
-  assert.equal(updatedContact.phone, '555-0000');
+  createdContact = await response.json();
+  assert.equal(createdContact.name, 'Ada King');
+  assert.equal(createdContact.email, 'ada.king@example.com');
+  assert.equal(createdContact.phone, '555-0000');
+});
 
-  const deleteResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+test('delete contact via DELETE returns 204', async () => {
+  const response = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
     method: 'DELETE',
   });
 
-  assert.equal(deleteResponse.status, 204);
-  assert.equal(deleteResponse.headers.get('content-type'), 'application/json');
-  assert.equal(await deleteResponse.text(), '');
-
-  const missingResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
-  assert.equal(missingResponse.status, 404);
-  assert.equal(missingResponse.headers.get('content-type'), 'application/json');
-  assert.deepEqual(await missingResponse.json(), { error: 'Not Found' });
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.equal(await response.text(), '');
 });
 
-test('unsupported methods return 405', async () => {
-  const response = await fetch(`${baseUrl}/api/contacts`, {
-    method: 'PATCH',
-  });
+test('get deleted contact returns 404', async () => {
+  const response = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
 
-  assert.equal(response.status, 405);
+  assert.equal(response.status, 404);
   assert.equal(response.headers.get('content-type'), 'application/json');
-  assert.deepEqual(await response.json(), { error: 'Method Not Allowed' });
+  assert.deepEqual(await response.json(), { error: 'Not Found' });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -15,12 +15,14 @@ function createApp() {
   });
 }
 
-const server = createApp();
-
 function startServer(port = PORT) {
+  const server = createApp();
+
   return new Promise((resolve) => {
     server.listen(port, () => {
-      console.log(`Listening on :${port}`);
+      const address = server.address();
+      const resolvedPort = typeof address === 'object' && address ? address.port : port;
+      console.log(`Listening on :${resolvedPort}`);
       resolve(server);
     });
   });
@@ -32,4 +34,4 @@ if (isMainModule) {
   startServer();
 }
 
-export { createApp, server, startServer };
+export { createApp, startServer };


### PR DESCRIPTION
## Summary\n- split the API coverage into the 7 requested node:test cases\n- start the server on an ephemeral port during tests and close it cleanly\n- refactor startServer() to create and return a fresh server instance\n\n## Validation\n- npm test