### PR TITLE
feat(api): add pagination to contacts list endpoint

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -11,6 +11,22 @@ const dbPath = path.resolve(__dirname, '..', 'data', 'contacts.db');
 let server;
 let baseUrl;
 
+async function createContact(overrides = {}) {
+  const response = await fetch(`${baseUrl}/api/contacts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      phone: '123-456-7890',
+      ...overrides,
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  return response.json();
+}
+
 test.before(async () => {
   fs.rmSync(dbPath, { force: true });
 
@@ -38,38 +54,93 @@ test.after(async () => {
   fs.rmSync(dbPath, { force: true });
 });
 
-test('API contact lifecycle', async () => {
+test('API contact lifecycle and paginated list responses', async () => {
   const healthResponse = await fetch(`${baseUrl}/api/health`);
   assert.equal(healthResponse.status, 200);
   assert.equal(healthResponse.headers.get('content-type'), 'application/json');
   assert.deepEqual(await healthResponse.json(), { status: 'ok' });
 
-  const createResponse = await fetch(`${baseUrl}/api/contacts`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      name: 'Ada Lovelace',
-      email: 'ada@example.com',
-      phone: '123-456-7890',
-    }),
-  });
-  assert.equal(createResponse.status, 201);
-  const createdContact = await createResponse.json();
-  assert.equal(createdContact.name, 'Ada Lovelace');
-  assert.equal(createdContact.email, 'ada@example.com');
-  assert.equal(createdContact.phone, '123-456-7890');
-  assert.ok(createdContact.id);
+  const createdContacts = [];
+
+  for (let index = 1; index <= 25; index += 1) {
+    const contact = await createContact({
+      name: `Contact ${index}`,
+      email: `contact${index}@example.com`,
+      phone: `555-00${String(index).padStart(2, '0')}`,
+    });
+    createdContacts.push(contact);
+  }
 
   const listResponse = await fetch(`${baseUrl}/api/contacts`);
   assert.equal(listResponse.status, 200);
-  const contacts = await listResponse.json();
-  assert.ok(contacts.some((contact) => contact.id === createdContact.id));
+  assert.equal(listResponse.headers.get('content-type'), 'application/json');
+  assert.match(listResponse.headers.get('link'), /rel="first"/);
+  assert.match(listResponse.headers.get('link'), /rel="last"/);
+  assert.match(listResponse.headers.get('link'), /rel="next"/);
+  assert.doesNotMatch(listResponse.headers.get('link'), /rel="prev"/);
 
-  const getResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  const listPayload = await listResponse.json();
+  assert.equal(listPayload.pagination.total, 25);
+  assert.equal(listPayload.pagination.limit, 20);
+  assert.equal(listPayload.pagination.offset, 0);
+  assert.equal(listPayload.data.length, 20);
+  assert.equal(listPayload.data[0].id, createdContacts[0].id);
+  assert.equal(listPayload.data.at(-1).id, createdContacts[19].id);
+
+  const customListResponse = await fetch(`${baseUrl}/api/contacts?limit=5&offset=20`);
+  assert.equal(customListResponse.status, 200);
+  const customLinkHeader = customListResponse.headers.get('link');
+  assert.match(customLinkHeader, /rel="first"/);
+  assert.match(customLinkHeader, /rel="last"/);
+  assert.match(customLinkHeader, /rel="prev"/);
+  assert.doesNotMatch(customLinkHeader, /rel="next"/);
+  assert.match(customLinkHeader, /offset=15[^>]*>; rel="prev"/);
+  assert.match(customLinkHeader, /offset=20[^>]*>; rel="last"/);
+
+  const customPayload = await customListResponse.json();
+  assert.equal(customPayload.pagination.total, 25);
+  assert.equal(customPayload.pagination.limit, 5);
+  assert.equal(customPayload.pagination.offset, 20);
+  assert.equal(customPayload.data.length, 5);
+  assert.deepEqual(
+    customPayload.data.map((contact) => contact.id),
+    createdContacts.slice(20).map((contact) => contact.id),
+  );
+
+  const oversizedLimitResponse = await fetch(`${baseUrl}/api/contacts?limit=200`);
+  assert.equal(oversizedLimitResponse.status, 200);
+  const oversizedLimitPayload = await oversizedLimitResponse.json();
+  assert.equal(oversizedLimitPayload.pagination.limit, 100);
+  assert.equal(oversizedLimitPayload.data.length, 25);
+  assert.match(oversizedLimitResponse.headers.get('link'), /offset=0[^>]*>; rel="last"/);
+
+  const beyondTotalResponse = await fetch(`${baseUrl}/api/contacts?limit=10&offset=999`);
+  assert.equal(beyondTotalResponse.status, 200);
+  const beyondTotalPayload = await beyondTotalResponse.json();
+  assert.equal(beyondTotalPayload.pagination.total, 25);
+  assert.equal(beyondTotalPayload.pagination.limit, 10);
+  assert.equal(beyondTotalPayload.pagination.offset, 999);
+  assert.deepEqual(beyondTotalPayload.data, []);
+  assert.match(beyondTotalResponse.headers.get('link'), /rel="prev"/);
+  assert.doesNotMatch(beyondTotalResponse.headers.get('link'), /rel="next"/);
+
+  const invalidLimitResponse = await fetch(`${baseUrl}/api/contacts?limit=abc`);
+  assert.equal(invalidLimitResponse.status, 400);
+  assert.deepEqual(await invalidLimitResponse.json(), {
+    error: 'limit must be a positive integer',
+  });
+
+  const negativeOffsetResponse = await fetch(`${baseUrl}/api/contacts?offset=-1`);
+  assert.equal(negativeOffsetResponse.status, 400);
+  assert.deepEqual(await negativeOffsetResponse.json(), {
+    error: 'offset must be a non-negative integer',
+  });
+
+  const getResponse = await fetch(`${baseUrl}/api/contacts/${createdContacts[0].id}`);
   assert.equal(getResponse.status, 200);
-  assert.deepEqual(await getResponse.json(), createdContact);
+  assert.deepEqual(await getResponse.json(), createdContacts[0]);
 
-  const updateResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+  const updateResponse = await fetch(`${baseUrl}/api/contacts/${createdContacts[0].id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -80,18 +151,18 @@ test('API contact lifecycle', async () => {
   });
   assert.equal(updateResponse.status, 200);
   const updatedContact = await updateResponse.json();
-  assert.equal(updatedContact.id, createdContact.id);
+  assert.equal(updatedContact.id, createdContacts[0].id);
   assert.equal(updatedContact.name, 'Ada King');
   assert.equal(updatedContact.email, 'ada.king@example.com');
   assert.equal(updatedContact.phone, '555-0000');
 
-  const deleteResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`, {
+  const deleteResponse = await fetch(`${baseUrl}/api/contacts/${createdContacts[0].id}`, {
     method: 'DELETE',
   });
   assert.equal(deleteResponse.status, 204);
   assert.equal(await deleteResponse.text(), '');
 
-  const deletedGetResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
+  const deletedGetResponse = await fetch(`${baseUrl}/api/contacts/${createdContacts[0].id}`);
   assert.equal(deletedGetResponse.status, 404);
   assert.deepEqual(await deletedGetResponse.json(), { error: 'Not Found' });
 });

--- a/src/db.js
+++ b/src/db.js
@@ -28,6 +28,18 @@ const selectAllStmt = db.prepare(`
   ORDER BY id ASC
 `);
 
+const selectPaginatedStmt = db.prepare(`
+  SELECT id, name, email, phone, created_at
+  FROM contacts
+  ORDER BY id ASC
+  LIMIT ? OFFSET ?
+`);
+
+const countAllStmt = db.prepare(`
+  SELECT COUNT(*) AS total
+  FROM contacts
+`);
+
 const selectByIdStmt = db.prepare(`
   SELECT id, name, email, phone, created_at
   FROM contacts
@@ -70,6 +82,14 @@ export function getAll() {
   return selectAllStmt.all();
 }
 
+export function getPaginated(limit, offset) {
+  return selectPaginatedStmt.all(limit, offset);
+}
+
+export function countAll() {
+  return countAllStmt.get().total;
+}
+
 export function getById(id) {
   return selectByIdStmt.get(id) ?? null;
 }
@@ -96,4 +116,3 @@ export function deleteById(id) {
   const result = deleteStmt.run(id);
   return result.changes > 0;
 }
-

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,10 @@
-import { create, deleteById, getAll, getById, update } from './db.js';
+import { countAll, create, deleteById, getById, getPaginated, update } from './db.js';
 
-function sendJson(res, statusCode, payload) {
-  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function sendJson(res, statusCode, payload, headers = {}) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json', ...headers });
   res.end(payload === undefined ? '' : JSON.stringify(payload));
 }
 
@@ -42,6 +45,59 @@ function parseContactId(pathname) {
   return match ? Number(match[1]) : null;
 }
 
+function parsePagination(searchParams) {
+  const limitParam = searchParams.get('limit');
+  const offsetParam = searchParams.get('offset');
+
+  let limit = DEFAULT_LIMIT;
+  let offset = 0;
+
+  if (limitParam !== null) {
+    limit = Number(limitParam);
+
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new Error('limit must be a positive integer');
+    }
+
+    limit = Math.min(limit, MAX_LIMIT);
+  }
+
+  if (offsetParam !== null) {
+    offset = Number(offsetParam);
+
+    if (!Number.isInteger(offset) || offset < 0) {
+      throw new Error('offset must be a non-negative integer');
+    }
+  }
+
+  return { limit, offset };
+}
+
+function buildPageUrl(url, req, offset, limit) {
+  const pageUrl = new URL(url.pathname, `http://${req.headers.host ?? 'localhost'}`);
+  pageUrl.searchParams.set('limit', String(limit));
+  pageUrl.searchParams.set('offset', String(offset));
+  return pageUrl.toString();
+}
+
+function buildLinkHeader(url, req, total, limit, offset) {
+  const links = [];
+  const lastOffset = total === 0 ? 0 : Math.floor((total - 1) / limit) * limit;
+
+  links.push(`<${buildPageUrl(url, req, 0, limit)}>; rel="first"`);
+  links.push(`<${buildPageUrl(url, req, lastOffset, limit)}>; rel="last"`);
+
+  if (offset > 0) {
+    links.push(`<${buildPageUrl(url, req, Math.max(0, offset - limit), limit)}>; rel="prev"`);
+  }
+
+  if (offset + limit < total) {
+    links.push(`<${buildPageUrl(url, req, offset + limit, limit)}>; rel="next"`);
+  }
+
+  return links.join(', ');
+}
+
 export async function router(req, res) {
   const method = req.method ?? 'GET';
   const url = new URL(req.url ?? '/', 'http://localhost');
@@ -58,7 +114,24 @@ export async function router(req, res) {
 
     if (pathname === '/api/contacts') {
       if (method === 'GET') {
-        return sendJson(res, 200, getAll());
+        const { limit, offset } = parsePagination(url.searchParams);
+        const total = countAll();
+        const data = getPaginated(limit, offset);
+        const link = buildLinkHeader(url, req, total, limit, offset);
+
+        return sendJson(
+          res,
+          200,
+          {
+            data,
+            pagination: {
+              total,
+              limit,
+              offset,
+            },
+          },
+          { Link: link },
+        );
       }
 
       if (method === 'POST') {
@@ -105,6 +178,14 @@ export async function router(req, res) {
     }
 
     if (error instanceof Error && error.message === 'name is required') {
+      return sendJson(res, 400, { error: error.message });
+    }
+
+    if (
+      error instanceof Error
+      && (error.message === 'limit must be a positive integer'
+        || error.message === 'offset must be a non-negative integer')
+    ) {
       return sendJson(res, 400, { error: error.message });
     }
 


### PR DESCRIPTION
## Summary
- add `limit` / `offset` pagination to `GET /api/contacts`
- return RFC 8288 `Link` headers plus pagination metadata in the JSON body
- expand API tests to cover default/custom pagination, invalid params, limit clamping, and existing CRUD behavior

## Notes
- The ticket refers to `/api/users`, but this repository currently exposes `/api/contacts`, so the change was applied to the existing collection endpoint.
- The provided worktree path was incomplete in this environment; implementation and validation were completed in the canonical repo checkout for the same repository/branch.

## Validation
- `npm test`