### PR TITLE
Ticket 172: Add dispatch-status endpoint (E2E-62)

### DIFF
--- a/src/dispatch-status.test.js
+++ b/src/dispatch-status.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  const { createApp } = await import('./server.js');
+  server = createApp();
+
+  await new Promise((resolve) => {
+    server.listen(0, () => resolve());
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('GET /dispatch-status returns expected payload', async () => {
+  const response = await fetch(`${baseUrl}/dispatch-status`);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+
+  const body = await response.json();
+
+  assert.ok('service' in body, 'body should contain service');
+  assert.ok('dispatchBridge' in body, 'body should contain dispatchBridge');
+  assert.ok('ticket' in body, 'body should contain ticket');
+  assert.ok('timestamp' in body, 'body should contain timestamp');
+
+  assert.equal(body.service, 'oc-test-app');
+  assert.equal(body.dispatchBridge, 'active');
+  assert.equal(body.ticket, 'E2E-62');
+  assert.ok(!isNaN(Date.parse(body.timestamp)), 'timestamp should be a valid ISO string');
+});

--- a/src/router.js
+++ b/src/router.js
@@ -48,6 +48,19 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    if (pathname === '/dispatch-status') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, {
+        service: 'oc-test-app',
+        dispatchBridge: 'active',
+        ticket: 'E2E-62',
+        timestamp: new Date().toISOString(),
+      });
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);


### PR DESCRIPTION
## Summary
Adds a `/dispatch-status` route that returns service status JSON for the team dispatch bridge test (E2E-62).

### Changes
- **src/router.js**: Added `/dispatch-status` GET route returning `{service, dispatchBridge, ticket, timestamp}`
- **src/dispatch-status.test.js**: E2E test asserting status 200, required keys, and `dispatchBridge === "active"`

### Test results
All tests pass (`npm test`: 2/2 passing).

Refs: Ticket 172