### PR TITLE
feat(health): add GET /health endpoint

### DIFF
--- a/src/health.test.js
+++ b/src/health.test.js
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createApp } from './server.js';
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  server = createApp();
+
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (!server) {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+});
+
+test('GET /health returns JSON ok status with current ISO timestamp', async () => {
+  const startedAt = Date.now();
+  const response = await fetch(`${baseUrl}/health`);
+  const endedAt = Date.now();
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+
+  const body = await response.json();
+  assert.equal(body.status, 'ok');
+  assert.equal(typeof body.timestamp, 'string');
+
+  const timestampMs = Date.parse(body.timestamp);
+  assert.notEqual(Number.isNaN(timestampMs), true);
+  assert.equal(new Date(timestampMs).toISOString(), body.timestamp);
+  assert.ok(timestampMs >= startedAt - 1000);
+  assert.ok(timestampMs <= endedAt + 1000);
+});

--- a/src/router.js
+++ b/src/router.js
@@ -48,6 +48,17 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    if (pathname === '/health') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, {
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+      });
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);

--- a/tasks/plans/198.md
+++ b/tasks/plans/198.md
@@ -1,0 +1,4 @@
+- Inspect router and tests
+- Add GET /health without changing existing /api/health behavior
+- Add isolated node:test coverage for /health
+- Run npm test

--- a/tasks/reports/198.md
+++ b/tasks/reports/198.md
@@ -1,0 +1,12 @@
+# Ticket 198 report
+
+## Changes
+- Added GET /health route returning {status:"ok", timestamp:<ISO>}
+- Added isolated node:test coverage in src/health.test.js
+- Left existing /api/health behavior unchanged
+
+## Validation
+- npm test ✅
+
+## Rollback
+- git revert <commit>


### PR DESCRIPTION
## Summary
- add a top-level `GET /health` route returning JSON status and ISO timestamp
- add focused `node:test` coverage for `/health`
- keep existing `/api/health` behavior unchanged

## Validation
- npm test