### PR TITLE
[Ticket-207] E2E-A27: Stale triage test

### DIFF
--- a/src/stale-triage-recovery.js
+++ b/src/stale-triage-recovery.js
@@ -1,0 +1,20 @@
+export function checkTriageTimeout(startTime, maxDurationMs, now = Date.now()) {
+  const startedAt = typeof startTime === 'number' ? startTime : new Date(startTime).getTime();
+
+  if (!Number.isFinite(startedAt)) {
+    throw new TypeError('startTime must be a valid timestamp or date value');
+  }
+
+  if (!Number.isFinite(maxDurationMs) || maxDurationMs < 0) {
+    throw new TypeError('maxDurationMs must be a non-negative number');
+  }
+
+  const elapsedMs = Math.max(0, now - startedAt);
+  const isStale = elapsedMs > maxDurationMs;
+
+  return {
+    isStale,
+    elapsedMs,
+    recoveryAction: isStale ? 'requeue-triage' : 'continue-triage',
+  };
+}

--- a/src/stale-triage-recovery.test.js
+++ b/src/stale-triage-recovery.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { checkTriageTimeout } from './stale-triage-recovery.js';
+
+test('flags triage as stale when elapsed time exceeds the timeout threshold', () => {
+  const now = Date.UTC(2026, 2, 31, 22, 39, 0);
+  const tenMinutesAgo = now - (10 * 60 * 1000);
+  const fiveMinuteLimit = 5 * 60 * 1000;
+
+  const result = checkTriageTimeout(tenMinutesAgo, fiveMinuteLimit, now);
+
+  assert.equal(result.isStale, true);
+  assert.equal(result.elapsedMs, 10 * 60 * 1000);
+  assert.equal(result.recoveryAction, 'requeue-triage');
+});
+
+test('keeps triage active when elapsed time stays within the timeout threshold', () => {
+  const now = Date.UTC(2026, 2, 31, 22, 39, 0);
+  const oneMinuteAgo = now - (1 * 60 * 1000);
+  const fiveMinuteLimit = 5 * 60 * 1000;
+
+  const result = checkTriageTimeout(oneMinuteAgo, fiveMinuteLimit, now);
+
+  assert.equal(result.isStale, false);
+  assert.equal(result.elapsedMs, 1 * 60 * 1000);
+  assert.equal(result.recoveryAction, 'continue-triage');
+});
+
+test('accepts ISO date strings for start time to match ticket metadata inputs', () => {
+  const now = Date.UTC(2026, 2, 31, 22, 39, 0);
+  const result = checkTriageTimeout('2026-03-31T22:29:00.000Z', 5 * 60 * 1000, now);
+
+  assert.equal(result.isStale, true);
+  assert.equal(result.recoveryAction, 'requeue-triage');
+});


### PR DESCRIPTION
## Summary
- add a small stale-triage recovery utility
- add node:test coverage for stale vs non-stale triage timeouts
- validate the full test suite passes

## Testing
- npm test