### PR TITLE
TK-219: refresh lockfile for better-sqlite3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^12.8.0"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",


### PR DESCRIPTION
## Summary
- validate the reported better-sqlite3 test failure in a fresh clone
- run npm install to materialize dependencies and refresh package-lock.json
- verify npm test passes locally

## Notes
- package.json already contained `better-sqlite3` on clone; the only tracked repo change was the lockfile refresh

## Validation
- npm install
- npm test