### PR TITLE
feat(settings): add settings CRUD API and page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "node src/server.js",
-    "test": "node --test src/**/*.test.js",
+    "test": "node --test src/*.test.js src/**/*.test.js",
     "typecheck": "echo 'no TypeScript configured'"
   },
   "dependencies": {

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -44,6 +44,45 @@ test('API contact lifecycle', async () => {
   assert.equal(healthResponse.headers.get('content-type'), 'application/json');
   assert.deepEqual(await healthResponse.json(), { status: 'ok' });
 
+  const settingsPageResponse = await fetch(`${baseUrl}/settings`);
+  assert.equal(settingsPageResponse.status, 200);
+  assert.match(settingsPageResponse.headers.get('content-type'), /^text\/html;/);
+  assert.match(await settingsPageResponse.text(), /<h1>Settings<\/h1>/);
+
+  const createSettingResponse = await fetch(`${baseUrl}/api/settings/theme`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value: 'dark' }),
+  });
+  assert.equal(createSettingResponse.status, 200);
+  assert.deepEqual(await createSettingResponse.json(), { key: 'theme', value: 'dark' });
+
+  const listSettingsResponse = await fetch(`${baseUrl}/api/settings`);
+  assert.equal(listSettingsResponse.status, 200);
+  assert.deepEqual(await listSettingsResponse.json(), [{ key: 'theme', value: 'dark' }]);
+
+  const getSettingResponse = await fetch(`${baseUrl}/api/settings/theme`);
+  assert.equal(getSettingResponse.status, 200);
+  assert.deepEqual(await getSettingResponse.json(), { key: 'theme', value: 'dark' });
+
+  const updateSettingResponse = await fetch(`${baseUrl}/api/settings/theme`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value: 'light' }),
+  });
+  assert.equal(updateSettingResponse.status, 200);
+  assert.deepEqual(await updateSettingResponse.json(), { key: 'theme', value: 'light' });
+
+  const deleteSettingResponse = await fetch(`${baseUrl}/api/settings/theme`, {
+    method: 'DELETE',
+  });
+  assert.equal(deleteSettingResponse.status, 204);
+  assert.equal(await deleteSettingResponse.text(), '');
+
+  const missingSettingResponse = await fetch(`${baseUrl}/api/settings/theme`);
+  assert.equal(missingSettingResponse.status, 404);
+  assert.deepEqual(await missingSettingResponse.json(), { error: 'Not Found' });
+
   const createResponse = await fetch(`${baseUrl}/api/contacts`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/router.js
+++ b/src/router.js
@@ -1,8 +1,20 @@
 import { create, deleteById, getAll, getById, update } from './db.js';
+import {
+  deleteByKey,
+  getAll as getAllSettings,
+  getByKey,
+  upsert,
+} from './settings/settingsDb.js';
+import { renderSettingsPage } from './settings/settingsPage.js';
 
 function sendJson(res, statusCode, payload) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
   res.end(payload === undefined ? '' : JSON.stringify(payload));
+}
+
+function sendHtml(res, statusCode, html) {
+  res.writeHead(statusCode, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(html);
 }
 
 function sendMethodNotAllowed(res) {
@@ -42,12 +54,25 @@ function parseContactId(pathname) {
   return match ? Number(match[1]) : null;
 }
 
+function parseSettingKey(pathname) {
+  const match = pathname.match(/^\/api\/settings\/([^/]+)$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 export async function router(req, res) {
   const method = req.method ?? 'GET';
   const url = new URL(req.url ?? '/', 'http://localhost');
   const { pathname } = url;
 
   try {
+    if (pathname === '/settings') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendHtml(res, 200, renderSettingsPage());
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);
@@ -65,6 +90,14 @@ export async function router(req, res) {
         const body = await readJsonBody(req);
         const contact = create(body);
         return sendJson(res, 201, contact);
+      }
+
+      return sendMethodNotAllowed(res);
+    }
+
+    if (pathname === '/api/settings') {
+      if (method === 'GET') {
+        return sendJson(res, 200, getAllSettings());
       }
 
       return sendMethodNotAllowed(res);
@@ -98,6 +131,33 @@ export async function router(req, res) {
       return sendMethodNotAllowed(res);
     }
 
+    const settingKey = parseSettingKey(pathname);
+
+    if (settingKey !== null) {
+      if (method === 'GET') {
+        const setting = getByKey(settingKey);
+        return setting ? sendJson(res, 200, setting) : sendNotFound(res);
+      }
+
+      if (method === 'PUT') {
+        const body = await readJsonBody(req);
+        return sendJson(res, 200, upsert(settingKey, body.value));
+      }
+
+      if (method === 'DELETE') {
+        const deleted = deleteByKey(settingKey);
+
+        if (!deleted) {
+          return sendNotFound(res);
+        }
+
+        res.writeHead(204, { 'Content-Type': 'application/json' });
+        return res.end();
+      }
+
+      return sendMethodNotAllowed(res);
+    }
+
     return sendNotFound(res);
   } catch (error) {
     if (error instanceof Error && error.message === 'Invalid JSON body') {
@@ -105,6 +165,13 @@ export async function router(req, res) {
     }
 
     if (error instanceof Error && error.message === 'name is required') {
+      return sendJson(res, 400, { error: error.message });
+    }
+
+    if (
+      error instanceof Error
+      && (error.message === 'key is required' || error.message === 'value must be a string')
+    ) {
       return sendJson(res, 400, { error: error.message });
     }
 

--- a/src/settings/settings.test.js
+++ b/src/settings/settings.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { createSettingsStore } from './settingsDb.js';
+
+test('settings store supports CRUD with a temporary SQLite file', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-test-app-settings-'));
+  const dbPath = path.join(tempDir, 'settings-test.db');
+  const store = createSettingsStore({ dbPath });
+
+  try {
+    assert.deepEqual(store.getAll(), []);
+    assert.equal(store.getByKey('theme'), null);
+
+    const created = store.upsert('theme', 'dark');
+    assert.deepEqual(created, { key: 'theme', value: 'dark' });
+    assert.deepEqual(store.getByKey('theme'), { key: 'theme', value: 'dark' });
+    assert.deepEqual(store.getAll(), [{ key: 'theme', value: 'dark' }]);
+
+    const updated = store.upsert('theme', 'light');
+    assert.deepEqual(updated, { key: 'theme', value: 'light' });
+    assert.deepEqual(store.getAll(), [{ key: 'theme', value: 'light' }]);
+
+    assert.equal(store.deleteByKey('theme'), true);
+    assert.equal(store.getByKey('theme'), null);
+    assert.deepEqual(store.getAll(), []);
+    assert.equal(store.deleteByKey('theme'), false);
+  } finally {
+    store.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('settings store validates required key and string value', () => {
+  const store = createSettingsStore({ dbPath: ':memory:' });
+
+  try {
+    assert.throws(() => store.getByKey('   '), /key is required/);
+    assert.throws(() => store.upsert('', 'value'), /key is required/);
+    assert.throws(() => store.upsert('theme', 123), /value must be a string/);
+  } finally {
+    store.close();
+  }
+});

--- a/src/settings/settingsDb.js
+++ b/src/settings/settingsDb.js
@@ -1,0 +1,110 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultDataDir = path.resolve(__dirname, '..', '..', 'data');
+const defaultDbPath = process.env.APP_DB_PATH || path.join(defaultDataDir, 'contacts.db');
+
+function normalizeKey(key) {
+  const normalizedKey = typeof key === 'string' ? key.trim() : '';
+
+  if (!normalizedKey) {
+    throw new Error('key is required');
+  }
+
+  return normalizedKey;
+}
+
+function normalizeValue(value) {
+  if (typeof value !== 'string') {
+    throw new Error('value must be a string');
+  }
+
+  return value;
+}
+
+export function createSettingsStore({ dbPath = defaultDbPath } = {}) {
+  if (dbPath !== ':memory:') {
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  }
+
+  const db = new Database(dbPath);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `);
+
+  const selectAllStmt = db.prepare(`
+    SELECT key, value
+    FROM settings
+    ORDER BY key ASC
+  `);
+
+  const selectByKeyStmt = db.prepare(`
+    SELECT key, value
+    FROM settings
+    WHERE key = ?
+  `);
+
+  const upsertStmt = db.prepare(`
+    INSERT INTO settings (key, value)
+    VALUES (@key, @value)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `);
+
+  const deleteStmt = db.prepare(`
+    DELETE FROM settings
+    WHERE key = ?
+  `);
+
+  return {
+    getAll() {
+      return selectAllStmt.all();
+    },
+
+    getByKey(key) {
+      return selectByKeyStmt.get(normalizeKey(key)) ?? null;
+    },
+
+    upsert(key, value) {
+      const normalizedKey = normalizeKey(key);
+      const normalizedValue = normalizeValue(value);
+
+      upsertStmt.run({ key: normalizedKey, value: normalizedValue });
+      return selectByKeyStmt.get(normalizedKey);
+    },
+
+    deleteByKey(key) {
+      const result = deleteStmt.run(normalizeKey(key));
+      return result.changes > 0;
+    },
+
+    close() {
+      db.close();
+    },
+  };
+}
+
+const settingsStore = createSettingsStore();
+
+export function getAll() {
+  return settingsStore.getAll();
+}
+
+export function getByKey(key) {
+  return settingsStore.getByKey(key);
+}
+
+export function upsert(key, value) {
+  return settingsStore.upsert(key, value);
+}
+
+export function deleteByKey(key) {
+  return settingsStore.deleteByKey(key);
+}

--- a/src/settings/settingsPage.js
+++ b/src/settings/settingsPage.js
@@ -1,0 +1,238 @@
+export function renderSettingsPage() {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Settings</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 2rem;
+        max-width: 900px;
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      form {
+        display: grid;
+        gap: 0.75rem;
+        max-width: 420px;
+        margin-bottom: 1.5rem;
+      }
+
+      label {
+        display: grid;
+        gap: 0.25rem;
+      }
+
+      input, button {
+        font: inherit;
+        padding: 0.5rem;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th, td {
+        padding: 0.75rem;
+        border-bottom: 1px solid #ddd;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      #message {
+        min-height: 1.5rem;
+        margin: 0.75rem 0;
+        color: #0a5;
+      }
+
+      #message.error {
+        color: #b00;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Settings</h1>
+      <p>Manage key-value application settings.</p>
+
+      <form id="settings-form">
+        <label>
+          Key
+          <input id="key" name="key" type="text" required>
+        </label>
+        <label>
+          Value
+          <input id="value" name="value" type="text" required>
+        </label>
+        <div class="actions">
+          <button type="submit">Save setting</button>
+          <button type="button" id="reset-form">Clear</button>
+        </div>
+      </form>
+
+      <div id="message" aria-live="polite"></div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Value</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody id="settings-table-body">
+          <tr>
+            <td colspan="3">Loading settings…</td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
+
+    <script>
+      const form = document.getElementById('settings-form');
+      const keyInput = document.getElementById('key');
+      const valueInput = document.getElementById('value');
+      const resetButton = document.getElementById('reset-form');
+      const message = document.getElementById('message');
+      const tableBody = document.getElementById('settings-table-body');
+
+      function showMessage(text, isError) {
+        message.textContent = text;
+        message.className = isError ? 'error' : '';
+      }
+
+      function escapeHtml(value) {
+        return value
+          .replaceAll('&', '&amp;')
+          .replaceAll('<', '&lt;')
+          .replaceAll('>', '&gt;')
+          .replaceAll('"', '&quot;')
+          .replaceAll("'", '&#39;');
+      }
+
+      function populateForm(setting) {
+        keyInput.value = setting.key;
+        valueInput.value = setting.value;
+        keyInput.focus();
+      }
+
+      function renderRows(settings) {
+        if (settings.length === 0) {
+          tableBody.innerHTML = '<tr><td colspan="3">No settings yet.</td></tr>';
+          return;
+        }
+
+        tableBody.innerHTML = settings.map(function (setting) {
+          const safeKey = escapeHtml(setting.key);
+          const safeValue = escapeHtml(setting.value);
+
+          return '<tr>'
+            + '<td>' + safeKey + '</td>'
+            + '<td>' + safeValue + '</td>'
+            + '<td><div class="actions">'
+            + '<button type="button" data-action="edit" data-key="' + safeKey + '">Edit</button>'
+            + '<button type="button" data-action="delete" data-key="' + safeKey + '">Delete</button>'
+            + '</div></td>'
+            + '</tr>';
+        }).join('');
+      }
+
+      async function loadSettings() {
+        const response = await fetch('/api/settings');
+        const settings = await response.json();
+        renderRows(settings);
+      }
+
+      form.addEventListener('submit', async function (event) {
+        event.preventDefault();
+        showMessage('', false);
+
+        const key = keyInput.value.trim();
+        const value = valueInput.value;
+
+        const response = await fetch('/api/settings/' + encodeURIComponent(key), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: value })
+        });
+
+        if (!response.ok) {
+          const payload = await response.json().catch(function () {
+            return { error: 'Request failed' };
+          });
+          showMessage(payload.error || 'Request failed', true);
+          return;
+        }
+
+        const savedSetting = await response.json();
+        showMessage('Saved ' + savedSetting.key + '.', false);
+        form.reset();
+        await loadSettings();
+      });
+
+      resetButton.addEventListener('click', function () {
+        form.reset();
+        showMessage('', false);
+        keyInput.focus();
+      });
+
+      tableBody.addEventListener('click', async function (event) {
+        const target = event.target;
+
+        if (!(target instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        const action = target.dataset.action;
+        const key = target.dataset.key;
+
+        if (!action || !key) {
+          return;
+        }
+
+        if (action === 'edit') {
+          const response = await fetch('/api/settings/' + encodeURIComponent(key));
+          const setting = await response.json();
+          populateForm(setting);
+          showMessage('Editing ' + setting.key + '.', false);
+          return;
+        }
+
+        if (action === 'delete') {
+          const response = await fetch('/api/settings/' + encodeURIComponent(key), {
+            method: 'DELETE'
+          });
+
+          if (!response.ok) {
+            const payload = await response.json().catch(function () {
+              return { error: 'Delete failed' };
+            });
+            showMessage(payload.error || 'Delete failed', true);
+            return;
+          }
+
+          showMessage('Deleted ' + key + '.', false);
+          await loadSettings();
+        }
+      });
+
+      loadSettings().catch(function (error) {
+        console.error(error);
+        showMessage('Failed to load settings.', true);
+        tableBody.innerHTML = '<tr><td colspan="3">Failed to load settings.</td></tr>';
+      });
+    </script>
+  </body>
+</html>`;
+}

--- a/tasks/plans/221.md
+++ b/tasks/plans/221.md
@@ -1,0 +1,7 @@
+# Ticket 221 plan
+
+1. Inspect current SQLite and router patterns.
+2. Add a settings SQLite layer with table auto-creation and CRUD helpers.
+3. Add `/api/settings*` routes and `/settings` HTML UI.
+4. Cover the new DB layer with temp-backed tests and extend API integration coverage.
+5. Run `npm test`, then commit/push/PR.

--- a/tasks/reports/221.md
+++ b/tasks/reports/221.md
@@ -1,0 +1,17 @@
+# Ticket 221 report
+
+## What changed
+- Added `src/settings/settingsDb.js` for SQLite-backed settings CRUD with table auto-creation.
+- Added `src/settings/settingsPage.js` for a simple HTML settings UI using `fetch()`.
+- Wired `/settings` and `/api/settings` CRUD routes into `src/router.js`.
+- Extended `src/api.test.js` to exercise the settings page and settings API.
+- Added `src/settings/settings.test.js` for temp-backed DB unit coverage.
+- Fixed `npm test` script so it runs both top-level and nested test files.
+
+## Validation
+- `node --test src/api.test.js` ✅
+- `npm test` ✅
+
+## Risk / rollback
+- Low risk: changes are isolated to routing and a new `settings` table in the existing SQLite DB file.
+- Rollback: revert the commit for this ticket.


### PR DESCRIPTION
## Summary
- add a SQLite-backed settings store with automatic table creation
- expose settings CRUD through `/api/settings` and add a `/settings` HTML page
- add settings coverage and fix `npm test` so both top-level and nested tests run

## Validation
- npm test