### PR TITLE
feat(settings): add settings page with CRUD API

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -6,13 +6,15 @@ import Database from 'better-sqlite3';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const dataDir = path.resolve(__dirname, '..', 'data');
-const dbPath = path.join(dataDir, 'contacts.db');
+const contactsDbPath = path.join(dataDir, 'contacts.db');
+const settingsDbPath = path.join(dataDir, 'settings.db');
 
 fs.mkdirSync(dataDir, { recursive: true });
 
-const db = new Database(dbPath);
+const contactsDb = new Database(contactsDbPath);
+const settingsDb = new Database(settingsDbPath);
 
-db.exec(`
+contactsDb.exec(`
   CREATE TABLE IF NOT EXISTS contacts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
@@ -22,24 +24,31 @@ db.exec(`
   )
 `);
 
-const selectAllStmt = db.prepare(`
+settingsDb.exec(`
+  CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT
+  )
+`);
+
+const selectAllStmt = contactsDb.prepare(`
   SELECT id, name, email, phone, created_at
   FROM contacts
   ORDER BY id ASC
 `);
 
-const selectByIdStmt = db.prepare(`
+const selectByIdStmt = contactsDb.prepare(`
   SELECT id, name, email, phone, created_at
   FROM contacts
   WHERE id = ?
 `);
 
-const insertStmt = db.prepare(`
+const insertStmt = contactsDb.prepare(`
   INSERT INTO contacts (name, email, phone)
   VALUES (@name, @email, @phone)
 `);
 
-const updateStmt = db.prepare(`
+const updateStmt = contactsDb.prepare(`
   UPDATE contacts
   SET name = @name,
       email = @email,
@@ -47,9 +56,32 @@ const updateStmt = db.prepare(`
   WHERE id = @id
 `);
 
-const deleteStmt = db.prepare(`
+const deleteStmt = contactsDb.prepare(`
   DELETE FROM contacts
   WHERE id = ?
+`);
+
+const selectAllSettingsStmt = settingsDb.prepare(`
+  SELECT key, value
+  FROM settings
+  ORDER BY key ASC
+`);
+
+const selectSettingStmt = settingsDb.prepare(`
+  SELECT key, value
+  FROM settings
+  WHERE key = ?
+`);
+
+const upsertSettingStmt = settingsDb.prepare(`
+  INSERT INTO settings (key, value)
+  VALUES (@key, @value)
+  ON CONFLICT(key) DO UPDATE SET value = excluded.value
+`);
+
+const deleteSettingStmt = settingsDb.prepare(`
+  DELETE FROM settings
+  WHERE key = ?
 `);
 
 function normalizeContactInput({ name, email = null, phone = null } = {}) {
@@ -63,6 +95,19 @@ function normalizeContactInput({ name, email = null, phone = null } = {}) {
     name: normalizedName,
     email: email ?? null,
     phone: phone ?? null,
+  };
+}
+
+function normalizeSettingInput(key, value) {
+  const normalizedKey = typeof key === 'string' ? key.trim() : '';
+
+  if (!normalizedKey) {
+    throw new Error('key is required');
+  }
+
+  return {
+    key: normalizedKey,
+    value: value == null ? '' : String(value),
   };
 }
 
@@ -97,3 +142,29 @@ export function deleteById(id) {
   return result.changes > 0;
 }
 
+export function getAllSettings() {
+  return selectAllSettingsStmt.all();
+}
+
+export function getSetting(key) {
+  return selectSettingStmt.get(key) ?? null;
+}
+
+export function upsertSetting(key, value) {
+  const normalized = normalizeSettingInput(key, value);
+  const existed = Boolean(getSetting(normalized.key));
+
+  upsertSettingStmt.run(normalized);
+
+  return {
+    setting: getSetting(normalized.key),
+    created: !existed,
+  };
+}
+
+export function deleteSetting(key) {
+  const result = deleteSettingStmt.run(key);
+  return result.changes > 0;
+}
+
+export { contactsDbPath, settingsDbPath };

--- a/src/router.js
+++ b/src/router.js
@@ -1,8 +1,13 @@
-import { create, deleteById, getAll, getById, update } from './db.js';
+import { create, deleteById, deleteSetting, getAll, getAllSettings, getById, getSetting, update, upsertSetting } from './db.js';
 
 function sendJson(res, statusCode, payload) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
   res.end(payload === undefined ? '' : JSON.stringify(payload));
+}
+
+function sendHtml(res, statusCode, html) {
+  res.writeHead(statusCode, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(html);
 }
 
 function sendMethodNotAllowed(res) {
@@ -42,12 +47,211 @@ function parseContactId(pathname) {
   return match ? Number(match[1]) : null;
 }
 
+function parseSettingKey(pathname) {
+  const match = pathname.match(/^\/api\/settings\/([^/]+)$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function renderSettingsPage(settings) {
+  const rows = settings.length
+    ? settings
+        .map(
+          (setting) => `
+            <tr>
+              <td>${escapeHtml(setting.key)}</td>
+              <td>${escapeHtml(setting.value ?? '')}</td>
+              <td>
+                <button type="button" data-action="edit" data-key="${escapeHtml(setting.key)}" data-value="${escapeHtml(setting.value ?? '')}">Edit</button>
+                <button type="button" data-action="delete" data-key="${escapeHtml(setting.key)}">Delete</button>
+              </td>
+            </tr>
+          `,
+        )
+        .join('')
+    : '<tr><td colspan="3">No settings saved yet.</td></tr>';
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Settings</title>
+    <style>
+      body { font-family: sans-serif; margin: 2rem; }
+      form { display: grid; gap: 0.75rem; max-width: 28rem; margin-bottom: 1.5rem; }
+      input, button { font: inherit; padding: 0.5rem; }
+      table { border-collapse: collapse; width: 100%; max-width: 48rem; }
+      th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+      .actions { display: flex; gap: 0.5rem; }
+      #status { margin: 1rem 0; min-height: 1.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Settings</h1>
+    <p>Manage key-value settings stored in SQLite.</p>
+
+    <form id="settings-form">
+      <label>
+        Key
+        <input id="key" name="key" required />
+      </label>
+      <label>
+        Value
+        <input id="value" name="value" />
+      </label>
+      <div class="actions">
+        <button type="submit">Save</button>
+        <button type="button" id="reset-form">Clear</button>
+      </div>
+    </form>
+
+    <div id="status" aria-live="polite"></div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Key</th>
+          <th>Value</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody id="settings-rows">${rows}</tbody>
+    </table>
+
+    <script>
+      const form = document.getElementById('settings-form');
+      const keyInput = document.getElementById('key');
+      const valueInput = document.getElementById('value');
+      const status = document.getElementById('status');
+      const resetButton = document.getElementById('reset-form');
+
+      function setStatus(message, isError = false) {
+        status.textContent = message;
+        status.style.color = isError ? 'crimson' : 'inherit';
+      }
+
+      async function refreshSettings() {
+        const response = await fetch('/api/settings');
+        const settings = await response.json();
+        const tbody = document.getElementById('settings-rows');
+
+        if (!settings.length) {
+          tbody.innerHTML = '<tr><td colspan="3">No settings saved yet.</td></tr>';
+          return;
+        }
+
+        tbody.innerHTML = settings.map((setting) => {
+          const key = String(setting.key)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
+          const value = String(setting.value ?? '')
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
+
+          return '<tr>'
+            + '<td>' + key + '</td>'
+            + '<td>' + value + '</td>'
+            + '<td>'
+            + '<button type="button" data-action="edit" data-key="' + key + '" data-value="' + value + '">Edit</button>'
+            + '<button type="button" data-action="delete" data-key="' + key + '">Delete</button>'
+            + '</td>'
+            + '</tr>';
+        }).join('');
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        setStatus('Saving...');
+
+        const response = await fetch('/api/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: keyInput.value, value: valueInput.value }),
+        });
+
+        if (!response.ok) {
+          const payload = await response.json();
+          setStatus(payload.error || 'Failed to save setting.', true);
+          return;
+        }
+
+        await refreshSettings();
+        setStatus('Setting saved.');
+      });
+
+      resetButton.addEventListener('click', () => {
+        form.reset();
+        keyInput.focus();
+        setStatus('');
+      });
+
+      document.body.addEventListener('click', async (event) => {
+        const button = event.target.closest('button[data-action]');
+
+        if (!button) {
+          return;
+        }
+
+        const { action, key, value } = button.dataset;
+
+        if (action === 'edit') {
+          keyInput.value = key;
+          valueInput.value = value || '';
+          keyInput.focus();
+          setStatus('Editing ' + key);
+          return;
+        }
+
+        if (action === 'delete') {
+          const response = await fetch('/api/settings/' + encodeURIComponent(key), { method: 'DELETE' });
+
+          if (!response.ok) {
+            const payload = await response.json();
+            setStatus(payload.error || 'Failed to delete setting.', true);
+            return;
+          }
+
+          if (keyInput.value === key) {
+            form.reset();
+          }
+
+          await refreshSettings();
+          setStatus('Deleted ' + key);
+        }
+      });
+    </script>
+  </body>
+</html>`;
+}
+
 export async function router(req, res) {
   const method = req.method ?? 'GET';
   const url = new URL(req.url ?? '/', 'http://localhost');
   const { pathname } = url;
 
   try {
+    if (pathname === '/settings') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendHtml(res, 200, renderSettingsPage(getAllSettings()));
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);
@@ -65,6 +269,20 @@ export async function router(req, res) {
         const body = await readJsonBody(req);
         const contact = create(body);
         return sendJson(res, 201, contact);
+      }
+
+      return sendMethodNotAllowed(res);
+    }
+
+    if (pathname === '/api/settings') {
+      if (method === 'GET') {
+        return sendJson(res, 200, getAllSettings());
+      }
+
+      if (method === 'POST') {
+        const body = await readJsonBody(req);
+        const { setting, created } = upsertSetting(body.key, body.value);
+        return sendJson(res, created ? 201 : 200, setting);
       }
 
       return sendMethodNotAllowed(res);
@@ -98,13 +316,35 @@ export async function router(req, res) {
       return sendMethodNotAllowed(res);
     }
 
+    const settingKey = parseSettingKey(pathname);
+
+    if (settingKey !== null) {
+      if (method === 'GET') {
+        const setting = getSetting(settingKey);
+        return setting ? sendJson(res, 200, setting) : sendNotFound(res);
+      }
+
+      if (method === 'DELETE') {
+        const deleted = deleteSetting(settingKey);
+
+        if (!deleted) {
+          return sendNotFound(res);
+        }
+
+        res.writeHead(204, { 'Content-Type': 'application/json' });
+        return res.end();
+      }
+
+      return sendMethodNotAllowed(res);
+    }
+
     return sendNotFound(res);
   } catch (error) {
     if (error instanceof Error && error.message === 'Invalid JSON body') {
       return sendJson(res, 400, { error: error.message });
     }
 
-    if (error instanceof Error && error.message === 'name is required') {
+    if (error instanceof Error && (error.message === 'name is required' || error.message === 'key is required')) {
       return sendJson(res, 400, { error: error.message });
     }
 

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const settingsDbPath = path.resolve(__dirname, '..', 'data', 'settings.db');
+
+let server;
+let baseUrl;
+let dbModule;
+
+function closeServer(currentServer) {
+  if (!currentServer) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    currentServer.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+test.before(async () => {
+  fs.rmSync(settingsDbPath, { force: true });
+
+  dbModule = await import('./db.js');
+  const { startServer } = await import('./server.js');
+  server = await startServer(0);
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  await closeServer(server);
+  fs.rmSync(settingsDbPath, { force: true });
+});
+
+test('settings table is created on initialization', () => {
+  assert.equal(fs.existsSync(settingsDbPath), true);
+
+  const sqlite = new Database(settingsDbPath, { readonly: true });
+  const table = sqlite
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'settings'")
+    .get();
+
+  sqlite.close();
+
+  assert.deepEqual(table, { name: 'settings' });
+});
+
+test('settings db helpers support CRUD with upsert behavior', () => {
+  const { deleteSetting, getAllSettings, getSetting, upsertSetting } = dbModule;
+
+  deleteSetting('theme');
+
+  const created = upsertSetting('theme', 'dark');
+  assert.equal(created.created, true);
+  assert.deepEqual(created.setting, { key: 'theme', value: 'dark' });
+  assert.deepEqual(getSetting('theme'), { key: 'theme', value: 'dark' });
+
+  const updated = upsertSetting('theme', 'light');
+  assert.equal(updated.created, false);
+  assert.deepEqual(updated.setting, { key: 'theme', value: 'light' });
+  assert.deepEqual(getAllSettings().find((setting) => setting.key === 'theme'), {
+    key: 'theme',
+    value: 'light',
+  });
+
+  assert.equal(deleteSetting('theme'), true);
+  assert.equal(getSetting('theme'), null);
+  assert.equal(deleteSetting('theme'), false);
+});
+
+test('settings API and HTML page work', async () => {
+  await fetch(`${baseUrl}/api/settings/test-key`, { method: 'DELETE' });
+
+  const pageResponse = await fetch(`${baseUrl}/settings`);
+  assert.equal(pageResponse.status, 200);
+  assert.match(pageResponse.headers.get('content-type') ?? '', /^text\/html/);
+  const pageHtml = await pageResponse.text();
+  assert.match(pageHtml, /<h1>Settings<\/h1>/);
+  assert.match(pageHtml, /Manage key-value settings stored in SQLite/);
+
+  const missingResponse = await fetch(`${baseUrl}/api/settings/test-key`);
+  assert.equal(missingResponse.status, 404);
+  assert.deepEqual(await missingResponse.json(), { error: 'Not Found' });
+
+  const invalidResponse = await fetch(`${baseUrl}/api/settings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value: 'missing-key' }),
+  });
+  assert.equal(invalidResponse.status, 400);
+  assert.deepEqual(await invalidResponse.json(), { error: 'key is required' });
+
+  const createResponse = await fetch(`${baseUrl}/api/settings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key: 'test-key', value: 'first-value' }),
+  });
+  assert.equal(createResponse.status, 201);
+  assert.deepEqual(await createResponse.json(), { key: 'test-key', value: 'first-value' });
+
+  const getResponse = await fetch(`${baseUrl}/api/settings/test-key`);
+  assert.equal(getResponse.status, 200);
+  assert.deepEqual(await getResponse.json(), { key: 'test-key', value: 'first-value' });
+
+  const listResponse = await fetch(`${baseUrl}/api/settings`);
+  assert.equal(listResponse.status, 200);
+  assert.ok((await listResponse.json()).some((setting) => setting.key === 'test-key' && setting.value === 'first-value'));
+
+  const updateResponse = await fetch(`${baseUrl}/api/settings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key: 'test-key', value: 'updated-value' }),
+  });
+  assert.equal(updateResponse.status, 200);
+  assert.deepEqual(await updateResponse.json(), { key: 'test-key', value: 'updated-value' });
+
+  const deleteResponse = await fetch(`${baseUrl}/api/settings/test-key`, { method: 'DELETE' });
+  assert.equal(deleteResponse.status, 204);
+  assert.equal(await deleteResponse.text(), '');
+
+  const deletedResponse = await fetch(`${baseUrl}/api/settings/test-key`);
+  assert.equal(deletedResponse.status, 404);
+  assert.deepEqual(await deletedResponse.json(), { error: 'Not Found' });
+});

--- a/tasks/plans/222.md
+++ b/tasks/plans/222.md
@@ -1,0 +1,17 @@
+# Ticket 222 plan
+
+## Scope
+- Preserve existing contacts API behavior.
+- Add SQLite-backed settings storage and CRUD API.
+- Add a minimal `/settings` HTML page.
+- Add automated coverage for settings DB + API.
+
+## Files
+- `src/db.js`
+- `src/router.js`
+- `src/settings.test.js`
+
+## Validation
+- `node --check src/router.js`
+- `npm test`
+- `timeout 5s npm run dev`

--- a/tasks/reports/222.md
+++ b/tasks/reports/222.md
@@ -1,0 +1,21 @@
+# Ticket 222 report
+
+## Changes
+- Added a separate SQLite settings store at `data/settings.db` with automatic table creation.
+- Extended `src/router.js` with:
+  - `GET /settings`
+  - `GET /api/settings`
+  - `GET /api/settings/:key`
+  - `POST /api/settings`
+  - `DELETE /api/settings/:key`
+- Added `src/settings.test.js` covering table creation, DB CRUD/upsert, API behavior, and HTML page availability.
+- Kept `data/` gitignored; no database files are tracked.
+
+## Validation evidence
+- `node --check src/router.js` ✅
+- `npm test` ✅
+- `timeout 5s npm run dev` ✅ (server started and logged `Listening on :3456` before timeout ended the process)
+
+## Risk / rollback
+- Risk is low and isolated to settings-specific SQLite/database routing changes.
+- Rollback: revert the commit for this ticket.


### PR DESCRIPTION
## Summary
- add SQLite-backed settings CRUD helpers and auto-create the settings table
- add settings API routes plus a minimal HTML settings page at /settings
- add tests for settings DB initialization, CRUD/upsert behavior, and API/page responses

## Validation
- node --check src/router.js
- npm test
- timeout 5s npm run dev