### PR TITLE
feat(health): add nodeVersion to /health endpoint response

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -42,7 +42,10 @@ test('API contact lifecycle', async () => {
   const healthResponse = await fetch(`${baseUrl}/api/health`);
   assert.equal(healthResponse.status, 200);
   assert.equal(healthResponse.headers.get('content-type'), 'application/json');
-  assert.deepEqual(await healthResponse.json(), { status: 'ok' });
+  assert.deepEqual(await healthResponse.json(), {
+    status: 'ok',
+    nodeVersion: process.version,
+  });
 
   const createResponse = await fetch(`${baseUrl}/api/contacts`, {
     method: 'POST',

--- a/src/router.js
+++ b/src/router.js
@@ -53,7 +53,7 @@ export async function router(req, res) {
         return sendMethodNotAllowed(res);
       }
 
-      return sendJson(res, 200, { status: 'ok' });
+      return sendJson(res, 200, { status: 'ok', nodeVersion: process.version });
     }
 
     if (pathname === '/api/contacts') {


### PR DESCRIPTION
## Summary
- add `nodeVersion: process.version` to the `/api/health` response
- update the API test to assert the health payload includes the runtime Node version

## Validation
- node --test src/**/*.test.js