### PR TITLE
feat(validation): add input validation to POST endpoints

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -11,6 +11,14 @@ const dbPath = path.resolve(__dirname, '..', 'data', 'contacts.db');
 let server;
 let baseUrl;
 
+async function createContact(body, headers = { 'Content-Type': 'application/json' }) {
+  return fetch(`${baseUrl}/api/contacts`, {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
 test.before(async () => {
   fs.rmSync(dbPath, { force: true });
 
@@ -44,15 +52,13 @@ test('API contact lifecycle', async () => {
   assert.equal(healthResponse.headers.get('content-type'), 'application/json');
   assert.deepEqual(await healthResponse.json(), { status: 'ok' });
 
-  const createResponse = await fetch(`${baseUrl}/api/contacts`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+  const createResponse = await createContact(
+    JSON.stringify({
       name: 'Ada Lovelace',
       email: 'ada@example.com',
       phone: '123-456-7890',
-    }),
-  });
+    })
+  );
   assert.equal(createResponse.status, 201);
   const createdContact = await createResponse.json();
   assert.equal(createdContact.name, 'Ada Lovelace');
@@ -94,4 +100,116 @@ test('API contact lifecycle', async () => {
   const deletedGetResponse = await fetch(`${baseUrl}/api/contacts/${createdContact.id}`);
   assert.equal(deletedGetResponse.status, 404);
   assert.deepEqual(await deletedGetResponse.json(), { error: 'Not Found' });
+});
+
+test('POST /api/contacts accepts valid name and description', async () => {
+  const response = await createContact(
+    JSON.stringify({
+      name: 'Grace Hopper',
+      description: 'Pioneer of computer programming.',
+    })
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+
+  const body = await response.json();
+  assert.equal(body.name, 'Grace Hopper');
+  assert.ok(body.id);
+});
+
+test('POST /api/contacts accepts valid name without description', async () => {
+  const response = await createContact(
+    JSON.stringify({
+      name: 'Katherine Johnson',
+    })
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+
+  const body = await response.json();
+  assert.equal(body.name, 'Katherine Johnson');
+  assert.ok(body.id);
+});
+
+test('POST /api/contacts rejects missing name', async () => {
+  const response = await createContact(JSON.stringify({ description: 'Missing name' }));
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), {
+    error: 'name is required and must be a string (max 100 characters)',
+  });
+});
+
+test('POST /api/contacts rejects non-string name', async () => {
+  const response = await createContact(JSON.stringify({ name: 42 }));
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), {
+    error: 'name is required and must be a string (max 100 characters)',
+  });
+});
+
+test('POST /api/contacts rejects name longer than 100 characters', async () => {
+  const response = await createContact(JSON.stringify({ name: 'a'.repeat(101) }));
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), {
+    error: 'name is required and must be a string (max 100 characters)',
+  });
+});
+
+test('POST /api/contacts rejects non-string description', async () => {
+  const response = await createContact(
+    JSON.stringify({
+      name: 'Margaret Hamilton',
+      description: 123,
+    })
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), {
+    error: 'description must be a string (max 500 characters)',
+  });
+});
+
+test('POST /api/contacts rejects description longer than 500 characters', async () => {
+  const response = await createContact(
+    JSON.stringify({
+      name: 'Margaret Hamilton',
+      description: 'd'.repeat(501),
+    })
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), {
+    error: 'description must be a string (max 500 characters)',
+  });
+});
+
+test('POST /api/contacts rejects malformed JSON', async () => {
+  const response = await createContact('{"name":', { 'Content-Type': 'application/json' });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), { error: 'Invalid JSON body' });
+});
+
+test('POST /api/health returns 405 with Allow header', async () => {
+  const response = await fetch(`${baseUrl}/api/health`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get('allow'), 'GET');
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(await response.json(), { error: 'Method not allowed' });
 });

--- a/src/db.js
+++ b/src/db.js
@@ -52,17 +52,47 @@ const deleteStmt = db.prepare(`
   WHERE id = ?
 `);
 
-function normalizeContactInput({ name, email = null, phone = null } = {}) {
-  const normalizedName = typeof name === 'string' ? name.trim() : '';
-
-  if (!normalizedName) {
-    throw new Error('name is required');
+function normalizeOptionalString(value, fieldName) {
+  if (value === undefined || value === null) {
+    return null;
   }
+
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string if provided`);
+  }
+
+  return value;
+}
+
+function normalizeDescription(description) {
+  if (description === undefined || description === null) {
+    return null;
+  }
+
+  if (typeof description !== 'string' || description.length > 500) {
+    throw new Error('description must be a string (max 500 characters)');
+  }
+
+  return description;
+}
+
+function normalizeContactInput({ name, email = null, phone = null, description = null } = {}) {
+  if (typeof name !== 'string') {
+    throw new Error('name is required and must be a string (max 100 characters)');
+  }
+
+  const normalizedName = name.trim();
+
+  if (!normalizedName || normalizedName.length > 100) {
+    throw new Error('name is required and must be a string (max 100 characters)');
+  }
+
+  normalizeDescription(description);
 
   return {
     name: normalizedName,
-    email: email ?? null,
-    phone: phone ?? null,
+    email: normalizeOptionalString(email, 'email'),
+    phone: normalizeOptionalString(phone, 'phone'),
   };
 }
 
@@ -96,4 +126,3 @@ export function deleteById(id) {
   const result = deleteStmt.run(id);
   return result.changes > 0;
 }
-

--- a/src/router.js
+++ b/src/router.js
@@ -1,12 +1,17 @@
 import { create, deleteById, getAll, getById, update } from './db.js';
 
-function sendJson(res, statusCode, payload) {
-  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+function sendJson(res, statusCode, payload, headers = {}) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json', ...headers });
   res.end(payload === undefined ? '' : JSON.stringify(payload));
 }
 
-function sendMethodNotAllowed(res) {
-  sendJson(res, 405, { error: 'Method Not Allowed' });
+function sendMethodNotAllowed(res, allow) {
+  const headers = allow ? { Allow: allow } : {};
+  sendJson(res, 405, { error: 'Method not allowed' }, headers);
+}
+
+function sendBadRequest(res, message) {
+  sendJson(res, 400, { error: message });
 }
 
 function sendNotFound(res) {
@@ -37,6 +42,25 @@ async function readJsonBody(req) {
   }
 }
 
+function validateCreateContactBody(body) {
+  if (!body || Array.isArray(body) || typeof body !== 'object') {
+    return 'Request body must be a JSON object';
+  }
+
+  if (typeof body.name !== 'string' || body.name.trim().length === 0 || body.name.length > 100) {
+    return 'name is required and must be a string (max 100 characters)';
+  }
+
+  if (
+    body.description !== undefined &&
+    (typeof body.description !== 'string' || body.description.length > 500)
+  ) {
+    return 'description must be a string (max 500 characters)';
+  }
+
+  return null;
+}
+
 function parseContactId(pathname) {
   const match = pathname.match(/^\/api\/contacts\/(\d+)$/);
   return match ? Number(match[1]) : null;
@@ -50,7 +74,7 @@ export async function router(req, res) {
   try {
     if (pathname === '/api/health') {
       if (method !== 'GET') {
-        return sendMethodNotAllowed(res);
+        return sendMethodNotAllowed(res, 'GET');
       }
 
       return sendJson(res, 200, { status: 'ok' });
@@ -63,6 +87,12 @@ export async function router(req, res) {
 
       if (method === 'POST') {
         const body = await readJsonBody(req);
+        const validationError = validateCreateContactBody(body);
+
+        if (validationError) {
+          return sendBadRequest(res, validationError);
+        }
+
         const contact = create(body);
         return sendJson(res, 201, contact);
       }
@@ -100,11 +130,13 @@ export async function router(req, res) {
 
     return sendNotFound(res);
   } catch (error) {
-    if (error instanceof Error && error.message === 'Invalid JSON body') {
-      return sendJson(res, 400, { error: error.message });
-    }
-
-    if (error instanceof Error && error.message === 'name is required') {
+    if (error instanceof Error && [
+      'Invalid JSON body',
+      'name is required and must be a string (max 100 characters)',
+      'description must be a string (max 500 characters)',
+      'email must be a string if provided',
+      'phone must be a string if provided',
+    ].includes(error.message)) {
       return sendJson(res, 400, { error: error.message });
     }
 

--- a/tasks/plans/262.md
+++ b/tasks/plans/262.md
@@ -1,0 +1,18 @@
+# Task 262 Plan
+
+## Scope
+- Add request validation for POST /api/contacts (repo uses contacts, not items)
+- Return JSON 400 for invalid/malformed bodies
+- Restrict POST /api/health with 405 and Allow: GET
+- Add tests for validation and method restriction
+
+## Files
+- src/router.js
+- src/db.js
+- src/api.test.js
+
+## Validation
+- npm test
+
+## Notes
+- Ticket refers to /api/items, but repo implements /api/contacts. Apply equivalent validation to existing POST endpoint without renaming API routes.

--- a/tasks/reports/262.md
+++ b/tasks/reports/262.md
@@ -1,0 +1,31 @@
+# Task 262 Report
+
+## What changed
+- Added JSON error handling and request validation for `POST /api/contacts`
+- Enforced `Allow: GET` and JSON 405 response for `POST /api/health`
+- Added regression + validation tests for valid and invalid POST scenarios
+
+## Files changed
+- `src/router.js`
+- `src/db.js`
+- `src/api.test.js`
+- `tasks/plans/262.md`
+
+## Validation evidence
+Command:
+```bash
+npm test
+```
+
+Result:
+- 10 tests passed
+- 0 failed
+
+## Risks / notes
+- Ticket brief referenced `/api/items`, but this repo exposes `/api/contacts`; implemented the equivalent validation on the existing POST endpoint to avoid breaking the app contract.
+- Existing unrelated workspace changes were left untouched (`package-lock.json`, `node_modules/`).
+
+## Rollback
+```bash
+git revert <commit-sha>
+```


### PR DESCRIPTION
## Summary
- add request validation for `POST /api/contacts` including malformed JSON handling
- return JSON 405 with `Allow: GET` for `POST /api/health`
- extend API tests to cover valid and invalid POST request cases

## Validation
- `npm test`