### PR TITLE
feat(health): add timestamp to /health response

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -42,7 +42,10 @@ test('API contact lifecycle', async () => {
   const healthResponse = await fetch(`${baseUrl}/api/health`);
   assert.equal(healthResponse.status, 200);
   assert.equal(healthResponse.headers.get('content-type'), 'application/json');
-  assert.deepEqual(await healthResponse.json(), { status: 'ok' });
+  const healthPayload = await healthResponse.json();
+  assert.equal(healthPayload.status, 'ok');
+  assert.match(healthPayload.timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  assert.equal(new Date(healthPayload.timestamp).toISOString(), healthPayload.timestamp);
 
   const createResponse = await fetch(`${baseUrl}/api/contacts`, {
     method: 'POST',

--- a/src/router.js
+++ b/src/router.js
@@ -53,7 +53,7 @@ export async function router(req, res) {
         return sendMethodNotAllowed(res);
       }
 
-      return sendJson(res, 200, { status: 'ok' });
+      return sendJson(res, 200, { status: 'ok', timestamp: new Date().toISOString() });
     }
 
     if (pathname === '/api/contacts') {


### PR DESCRIPTION
## Summary
- add a request-time ISO 8601 timestamp to the `/api/health` JSON response
- preserve the existing `status` field
- update the API test to assert the timestamp exists and is a valid ISO 8601 string

## Validation
- npm test