### PR TITLE
feat(health): add uptimeMs to /health response

### DIFF
--- a/src/api.test.js
+++ b/src/api.test.js
@@ -42,7 +42,19 @@ test('API contact lifecycle', async () => {
   const healthResponse = await fetch(`${baseUrl}/api/health`);
   assert.equal(healthResponse.status, 200);
   assert.equal(healthResponse.headers.get('content-type'), 'application/json');
-  assert.deepEqual(await healthResponse.json(), { status: 'ok' });
+  const healthPayload = await healthResponse.json();
+  assert.equal(healthPayload.status, 'ok');
+  assert.equal(typeof healthPayload.uptimeMs, 'number');
+  assert.equal(Number.isInteger(healthPayload.uptimeMs), true);
+  assert.equal(healthPayload.uptimeMs >= 0, true);
+
+  const nextHealthResponse = await fetch(`${baseUrl}/api/health`);
+  assert.equal(nextHealthResponse.status, 200);
+  const nextHealthPayload = await nextHealthResponse.json();
+  assert.equal(nextHealthPayload.status, 'ok');
+  assert.equal(typeof nextHealthPayload.uptimeMs, 'number');
+  assert.equal(Number.isInteger(nextHealthPayload.uptimeMs), true);
+  assert.equal(nextHealthPayload.uptimeMs >= healthPayload.uptimeMs, true);
 
   const createResponse = await fetch(`${baseUrl}/api/contacts`, {
     method: 'POST',

--- a/src/router.js
+++ b/src/router.js
@@ -53,7 +53,10 @@ export async function router(req, res) {
         return sendMethodNotAllowed(res);
       }
 
-      return sendJson(res, 200, { status: 'ok' });
+      return sendJson(res, 200, {
+        status: 'ok',
+        uptimeMs: Math.floor(process.uptime() * 1000),
+      });
     }
 
     if (pathname === '/api/contacts') {


### PR DESCRIPTION
## Summary
- add `uptimeMs` to the `/api/health` JSON response
- compute the value per request from `process.uptime()` in milliseconds
- update the API test to validate the new field and that it is non-negative/integer

## Validation
- `node --test src/**/*.test.js`