### PR TITLE
feat: add in-memory request rate limiter middleware

### DIFF
--- a/src/middleware/rateLimiter.js
+++ b/src/middleware/rateLimiter.js
@@ -1,0 +1,72 @@
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX_REQUESTS = 100;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60_000;
+
+function getClientIp(req) {
+  return req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+}
+
+function createRateLimiter({
+  limit = DEFAULT_MAX_REQUESTS,
+  windowMs = DEFAULT_WINDOW_MS,
+  cleanupIntervalMs = DEFAULT_CLEANUP_INTERVAL_MS,
+  now = () => Date.now(),
+} = {}) {
+  const store = new Map();
+
+  const cleanup = () => {
+    const currentTime = now();
+
+    for (const [ip, entry] of store.entries()) {
+      if (currentTime - entry.windowStart >= windowMs) {
+        store.delete(ip);
+      }
+    }
+  };
+
+  const cleanupInterval = setInterval(cleanup, cleanupIntervalMs);
+  cleanupInterval.unref?.();
+
+  const middleware = (req, res, next) => {
+    const currentTime = now();
+    const ip = getClientIp(req);
+    const entry = store.get(ip);
+
+    if (!entry || currentTime - entry.windowStart >= windowMs) {
+      store.set(ip, { count: 1, windowStart: currentTime });
+      next();
+      return;
+    }
+
+    entry.count += 1;
+
+    if (entry.count > limit) {
+      const remainingMs = Math.max(windowMs - (currentTime - entry.windowStart), 0);
+      const retryAfterSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
+
+      res.writeHead(429, {
+        'Content-Type': 'application/json',
+        'Retry-After': String(retryAfterSeconds),
+      });
+      res.end(JSON.stringify({ error: 'Too Many Requests' }));
+      return;
+    }
+
+    next();
+  };
+
+  middleware.store = store;
+  middleware.cleanup = cleanup;
+  middleware.reset = () => {
+    store.clear();
+  };
+  middleware.stopCleanup = () => {
+    clearInterval(cleanupInterval);
+  };
+
+  return middleware;
+}
+
+const rateLimiter = createRateLimiter();
+
+export { createRateLimiter, rateLimiter };

--- a/src/middleware/rateLimiter.test.js
+++ b/src/middleware/rateLimiter.test.js
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createApp } from '../server.js';
+import { createRateLimiter } from './rateLimiter.js';
+
+async function startTestServer(rateLimiter) {
+  const server = createApp({ rateLimiter });
+
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    server,
+    baseUrl,
+    async close() {
+      rateLimiter.stopCleanup();
+      await new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+test('allows up to 100 requests within the window', async () => {
+  const rateLimiter = createRateLimiter();
+  const app = await startTestServer(rateLimiter);
+
+  try {
+    for (let index = 0; index < 100; index += 1) {
+      const response = await fetch(`${app.baseUrl}/api/health`);
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { status: 'ok' });
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test('returns 429 on the 101st request within the same window', async () => {
+  const rateLimiter = createRateLimiter();
+  const app = await startTestServer(rateLimiter);
+
+  try {
+    for (let index = 0; index < 100; index += 1) {
+      const response = await fetch(`${app.baseUrl}/api/health`);
+      assert.equal(response.status, 200);
+      await response.arrayBuffer();
+    }
+
+    const response = await fetch(`${app.baseUrl}/api/health`);
+    assert.equal(response.status, 429);
+    assert.deepEqual(await response.json(), { error: 'Too Many Requests' });
+  } finally {
+    await app.close();
+  }
+});
+
+test('includes Retry-After header on rate-limited responses', async () => {
+  const rateLimiter = createRateLimiter();
+  const app = await startTestServer(rateLimiter);
+
+  try {
+    for (let index = 0; index < 100; index += 1) {
+      const response = await fetch(`${app.baseUrl}/api/health`);
+      assert.equal(response.status, 200);
+      await response.arrayBuffer();
+    }
+
+    const response = await fetch(`${app.baseUrl}/api/health`);
+    assert.equal(response.status, 429);
+    assert.ok(response.headers.get('retry-after'));
+  } finally {
+    await app.close();
+  }
+});
+
+test('allows requests again after the window resets', async () => {
+  let currentTime = 0;
+  const rateLimiter = createRateLimiter({ now: () => currentTime });
+  const app = await startTestServer(rateLimiter);
+
+  try {
+    for (let index = 0; index < 100; index += 1) {
+      const response = await fetch(`${app.baseUrl}/api/health`);
+      assert.equal(response.status, 200);
+      await response.arrayBuffer();
+    }
+
+    let response = await fetch(`${app.baseUrl}/api/health`);
+    assert.equal(response.status, 429);
+
+    currentTime += 60_001;
+
+    response = await fetch(`${app.baseUrl}/api/health`);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { status: 'ok' });
+  } finally {
+    await app.close();
+  }
+});

--- a/src/server.js
+++ b/src/server.js
@@ -1,16 +1,19 @@
 import http from 'node:http';
 import { fileURLToPath } from 'node:url';
 
+import { rateLimiter as defaultRateLimiter } from './middleware/rateLimiter.js';
 import { router } from './router.js';
 
 const PORT = Number(process.env.PORT || 3456);
 
-function createApp() {
+function createApp({ rateLimiter = defaultRateLimiter } = {}) {
   return http.createServer((req, res) => {
-    Promise.resolve(router(req, res)).catch((error) => {
-      console.error(error);
-      res.writeHead(500, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Internal Server Error' }));
+    rateLimiter(req, res, () => {
+      Promise.resolve(router(req, res)).catch((error) => {
+        console.error(error);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal Server Error' }));
+      });
     });
   });
 }

--- a/tasks/plans/269.md
+++ b/tasks/plans/269.md
@@ -1,0 +1,15 @@
+# Plan — Ticket 269
+
+## Scope
+- Add in-memory IP-based rate limiter middleware to the HTTP server.
+- Apply limiter globally before route handling.
+- Add integration-style tests against the real server.
+
+## Files
+- `src/middleware/rateLimiter.js`
+- `src/server.js`
+- `src/middleware/rateLimiter.test.js`
+- `tasks/reports/269.md`
+
+## Validation
+- `npm test`

--- a/tasks/reports/269.md
+++ b/tasks/reports/269.md
@@ -1,0 +1,28 @@
+# Report — Ticket 269
+
+## What changed
+- Added `src/middleware/rateLimiter.js` with an in-memory per-IP limiter:
+  - 100 requests per 60-second window
+  - `429` JSON response with `Retry-After`
+  - periodic eviction of expired entries
+  - exported factory plus cleanup/reset hooks for test teardown
+- Updated `src/server.js` to apply the limiter before routing.
+- Added `src/middleware/rateLimiter.test.js` covering:
+  - 100 requests allowed
+  - 101st request blocked
+  - `Retry-After` header present
+  - requests succeed again after window reset
+
+## Validation
+- `npm test` ✅
+- `node --test src/api.test.js src/middleware/rateLimiter.test.js` ✅
+
+## Risks / notes
+- Repo is plain `node:http`, not Express; limiter was implemented as HTTP middleware wrapper without adding dependencies.
+- Existing worktree had unrelated local state in `package-lock.json` and `node_modules/`; left untouched.
+
+## Rollback
+- Revert commit for this ticket or remove:
+  - `src/middleware/rateLimiter.js`
+  - limiter wiring in `src/server.js`
+  - `src/middleware/rateLimiter.test.js`


### PR DESCRIPTION
## Summary
- add an in-memory per-IP rate limiter middleware with cleanup hooks
- apply the limiter before routing in the HTTP server
- add integration-style tests for limit, 429, Retry-After, and window reset

## Validation
- npm test
- node --test src/api.test.js src/middleware/rateLimiter.test.js