### PR TITLE
feat(ping): add /ping health-check endpoint

### DIFF
--- a/src/ping.test.js
+++ b/src/ping.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  const { startServer } = await import('./server.js');
+  server = await startServer(0);
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+});
+
+test('GET /ping returns plain-text pong', async () => {
+  const response = await fetch(`${baseUrl}/ping`);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'text/plain');
+  assert.equal(await response.text(), 'pong');
+});

--- a/src/router.js
+++ b/src/router.js
@@ -48,6 +48,15 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    if (pathname === '/ping') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      return res.end('pong');
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);

--- a/tasks/reports/272.md
+++ b/tasks/reports/272.md
@@ -1,0 +1,26 @@
+# Ticket 272 report
+
+## Plan
+- Add a `GET /ping` route in `src/router.js` matching the existing HTTP router style.
+- Add a focused Node test in `src/ping.test.js`.
+- Run `npm test` before commit/PR.
+
+## Changes
+- `src/router.js`
+  - Added `GET /ping` returning `200`, `Content-Type: text/plain`, body `pong`.
+- `src/ping.test.js`
+  - Added endpoint test asserting status, content-type, and exact response body.
+
+## Validation
+```bash
+npm test
+```
+- Result: passed (`2` tests, `0` failures)
+
+## Risk
+- Low. Route addition is isolated and precedes existing API routing.
+
+## Rollback
+```bash
+git revert <commit>
+```


### PR DESCRIPTION
## Summary
- add a GET /ping health-check route returning plain-text `pong`
- add a focused Node test for the /ping endpoint
- include a small task report with validation evidence

## Validation
- npm test