### PR TITLE
feat: add /ready endpoint

### DIFF
--- a/src/ready.test.js
+++ b/src/ready.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createApp } from './server.js';
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  server = createApp();
+
+  await new Promise((resolve) => {
+    server.listen(0, () => {
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+});
+
+test('GET /ready returns ready=true JSON', async () => {
+  const response = await fetch(`${baseUrl}/ready`);
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get('content-type') ?? '', /^application\/json(?:;|$)/);
+  assert.deepEqual(await response.json(), { ready: true });
+});

--- a/src/router.js
+++ b/src/router.js
@@ -48,6 +48,14 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    if (pathname === '/ready') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, { ready: true });
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);


### PR DESCRIPTION
## Summary
- add a GET /ready endpoint that returns {"ready":true}
- add a node:test coverage for the new readiness endpoint
- verify the existing API tests still pass with npm test

## Testing
- npm test