### PR TITLE
feat(health): add GET /health endpoint with uptime and version

### DIFF
--- a/src/health.test.js
+++ b/src/health.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dbPath = path.resolve(__dirname, '..', 'data', 'contacts.db');
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  fs.rmSync(dbPath, { force: true });
+
+  const { createApp } = await import('./server.js');
+  server = createApp();
+
+  await new Promise((resolve) => {
+    server.listen(0, () => resolve());
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+});
+
+test('GET /health returns 200 with status, uptime, and version', async () => {
+  const res = await fetch(`${baseUrl}/health`);
+
+  assert.equal(res.status, 200);
+  assert.ok(res.headers.get('content-type').includes('application/json'));
+
+  const body = await res.json();
+
+  assert.equal(body.status, 'ok');
+  assert.equal(typeof body.uptime, 'number');
+  assert.ok(body.uptime > 0, 'uptime should be greater than 0');
+  assert.equal(body.version, pkg.version);
+
+  // Ensure no extra keys
+  const keys = Object.keys(body).sort();
+  assert.deepEqual(keys, ['status', 'uptime', 'version']);
+});

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { create, deleteById, getAll, getById, update } from './db.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
 
 function sendJson(res, statusCode, payload) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
@@ -48,6 +52,18 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    if (pathname === '/health') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, {
+        status: 'ok',
+        uptime: process.uptime(),
+        version,
+      });
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);


### PR DESCRIPTION
## Summary

Adds a `GET /health` endpoint that returns JSON with:
- `status`: `"ok"`
- `uptime`: current `process.uptime()`
- `version`: version from `package.json`

## Changes
- **src/router.js**: Added `/health` route returning status, uptime, and version
- **src/health.test.js**: New test file validating response status, content-type, and all payload fields

## Testing
All tests pass (`npm test` — 2/2 pass, 0 fail).

Closes #274