### PR TITLE
feat(metrics): add GET /metrics endpoint with request counter

### DIFF
--- a/src/metrics.test.js
+++ b/src/metrics.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dbPath = path.resolve(__dirname, '..', 'data', 'contacts.db');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  fs.rmSync(dbPath, { force: true });
+
+  const { resetRequestCount } = await import('./router.js');
+  resetRequestCount();
+
+  const { startServer } = await import('./server.js');
+  server = await startServer(0);
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  fs.rmSync(dbPath, { force: true });
+});
+
+test('GET /metrics returns JSON with requestCount', async () => {
+  const { resetRequestCount } = await import('./router.js');
+  resetRequestCount();
+
+  const res = await fetch(`${baseUrl}/metrics`);
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('content-type'), 'application/json');
+
+  const body = await res.json();
+  assert.equal(typeof body.requestCount, 'number');
+  assert.equal(body.requestCount, 1);
+});
+
+test('counter increments on every request including /metrics', async () => {
+  const { resetRequestCount } = await import('./router.js');
+  resetRequestCount();
+
+  await fetch(`${baseUrl}/api/health`);
+  await fetch(`${baseUrl}/api/contacts`);
+  await fetch(`${baseUrl}/metrics`);
+
+  const res = await fetch(`${baseUrl}/metrics`);
+  const body = await res.json();
+
+  assert.equal(body.requestCount, 4);
+});
+
+test('GET /metrics returns 405 for non-GET methods', async () => {
+  const res = await fetch(`${baseUrl}/metrics`, { method: 'POST' });
+  assert.equal(res.status, 405);
+  assert.deepEqual(await res.json(), { error: 'Method Not Allowed' });
+});

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,19 @@
 import { create, deleteById, getAll, getById, update } from './db.js';
 
+let requestCount = 0;
+
+function incrementRequestCount() {
+  requestCount++;
+}
+
+function getRequestCount() {
+  return requestCount;
+}
+
+function resetRequestCount() {
+  requestCount = 0;
+}
+
 function sendJson(res, statusCode, payload) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
   res.end(payload === undefined ? '' : JSON.stringify(payload));
@@ -43,11 +57,21 @@ function parseContactId(pathname) {
 }
 
 export async function router(req, res) {
+  incrementRequestCount();
+
   const method = req.method ?? 'GET';
   const url = new URL(req.url ?? '/', 'http://localhost');
   const { pathname } = url;
 
   try {
+    if (pathname === '/metrics') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, { requestCount: getRequestCount() });
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);
@@ -112,3 +136,5 @@ export async function router(req, res) {
     return sendJson(res, 500, { error: 'Internal Server Error' });
   }
 }
+
+export { getRequestCount, resetRequestCount };


### PR DESCRIPTION
## Summary
- Add `GET /metrics` endpoint returning `{ requestCount }` tracking total requests since startup
- Counter increments on every request including `/metrics` itself
- Add tests in `src/metrics.test.js` using `node:test` and `node:assert`

## Test plan
- [x] `npm test` passes all existing and new tests (4/4 pass)
- [x] Verified counter increments on all request types
- [x] Verified 405 for non-GET methods on `/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)