### PR TITLE
feat(readiness): add db-backed readiness endpoint

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -97,3 +97,5 @@ export function deleteById(id) {
   return result.changes > 0;
 }
 
+export { db };
+

--- a/src/readiness.test.js
+++ b/src/readiness.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createRouter } from './router.js';
+import { createApp } from './server.js';
+
+async function withServer(database, run) {
+  const app = createApp({ router: createRouter({ database }) });
+
+  await new Promise((resolve) => {
+    app.listen(0, () => resolve());
+  });
+
+  const address = app.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      app.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+}
+
+test('GET /readiness returns ok when database query succeeds', async () => {
+  const database = {
+    prepare(sql) {
+      assert.equal(sql, 'SELECT 1');
+      return {
+        get() {
+          return { 1: 1 };
+        },
+      };
+    },
+  };
+
+  await withServer(database, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/readiness`);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'application/json');
+    assert.deepEqual(await response.json(), { status: 'ok', checks: { db: 'ok' } });
+  });
+});
+
+test('GET /readiness returns degraded when database query fails', async () => {
+  const database = {
+    prepare() {
+      throw new Error('database unavailable');
+    },
+  };
+
+  await withServer(database, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/readiness`);
+
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('content-type'), 'application/json');
+    assert.deepEqual(await response.json(), {
+      status: 'degraded',
+      checks: { db: 'database unavailable' },
+    });
+  });
+});

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,4 @@
-import { create, deleteById, getAll, getById, update } from './db.js';
+import { create, db, deleteById, getAll, getById, update } from './db.js';
 
 function sendJson(res, statusCode, payload) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
@@ -42,73 +42,105 @@ function parseContactId(pathname) {
   return match ? Number(match[1]) : null;
 }
 
-export async function router(req, res) {
-  const method = req.method ?? 'GET';
-  const url = new URL(req.url ?? '/', 'http://localhost');
-  const { pathname } = url;
+function getErrorMessage(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
 
-  try {
-    if (pathname === '/api/health') {
-      if (method !== 'GET') {
+  return 'Unknown error';
+}
+
+function checkDbHealth(database) {
+  database.prepare('SELECT 1').get();
+}
+
+export function createRouter({ database = db } = {}) {
+  return async function router(req, res) {
+    const method = req.method ?? 'GET';
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const { pathname } = url;
+
+    try {
+      if (pathname === '/api/health') {
+        if (method !== 'GET') {
+          return sendMethodNotAllowed(res);
+        }
+
+        return sendJson(res, 200, { status: 'ok' });
+      }
+
+      if (pathname === '/readiness') {
+        if (method !== 'GET') {
+          return sendMethodNotAllowed(res);
+        }
+
+        try {
+          checkDbHealth(database);
+          return sendJson(res, 200, { status: 'ok', checks: { db: 'ok' } });
+        } catch (error) {
+          return sendJson(res, 503, {
+            status: 'degraded',
+            checks: { db: getErrorMessage(error) },
+          });
+        }
+      }
+
+      if (pathname === '/api/contacts') {
+        if (method === 'GET') {
+          return sendJson(res, 200, getAll());
+        }
+
+        if (method === 'POST') {
+          const body = await readJsonBody(req);
+          const contact = create(body);
+          return sendJson(res, 201, contact);
+        }
+
         return sendMethodNotAllowed(res);
       }
 
-      return sendJson(res, 200, { status: 'ok' });
-    }
+      const contactId = parseContactId(pathname);
 
-    if (pathname === '/api/contacts') {
-      if (method === 'GET') {
-        return sendJson(res, 200, getAll());
-      }
-
-      if (method === 'POST') {
-        const body = await readJsonBody(req);
-        const contact = create(body);
-        return sendJson(res, 201, contact);
-      }
-
-      return sendMethodNotAllowed(res);
-    }
-
-    const contactId = parseContactId(pathname);
-
-    if (contactId !== null) {
-      if (method === 'GET') {
-        const contact = getById(contactId);
-        return contact ? sendJson(res, 200, contact) : sendNotFound(res);
-      }
-
-      if (method === 'PUT') {
-        const body = await readJsonBody(req);
-        const contact = update(contactId, body);
-        return contact ? sendJson(res, 200, contact) : sendNotFound(res);
-      }
-
-      if (method === 'DELETE') {
-        const deleted = deleteById(contactId);
-
-        if (!deleted) {
-          return sendNotFound(res);
+      if (contactId !== null) {
+        if (method === 'GET') {
+          const contact = getById(contactId);
+          return contact ? sendJson(res, 200, contact) : sendNotFound(res);
         }
 
-        res.writeHead(204, { 'Content-Type': 'application/json' });
-        return res.end();
+        if (method === 'PUT') {
+          const body = await readJsonBody(req);
+          const contact = update(contactId, body);
+          return contact ? sendJson(res, 200, contact) : sendNotFound(res);
+        }
+
+        if (method === 'DELETE') {
+          const deleted = deleteById(contactId);
+
+          if (!deleted) {
+            return sendNotFound(res);
+          }
+
+          res.writeHead(204, { 'Content-Type': 'application/json' });
+          return res.end();
+        }
+
+        return sendMethodNotAllowed(res);
       }
 
-      return sendMethodNotAllowed(res);
-    }
+      return sendNotFound(res);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Invalid JSON body') {
+        return sendJson(res, 400, { error: error.message });
+      }
 
-    return sendNotFound(res);
-  } catch (error) {
-    if (error instanceof Error && error.message === 'Invalid JSON body') {
-      return sendJson(res, 400, { error: error.message });
-    }
+      if (error instanceof Error && error.message === 'name is required') {
+        return sendJson(res, 400, { error: error.message });
+      }
 
-    if (error instanceof Error && error.message === 'name is required') {
-      return sendJson(res, 400, { error: error.message });
+      console.error(error);
+      return sendJson(res, 500, { error: 'Internal Server Error' });
     }
-
-    console.error(error);
-    return sendJson(res, 500, { error: 'Internal Server Error' });
-  }
+  };
 }
+
+export const router = createRouter();

--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,11 @@
 import http from 'node:http';
 import { fileURLToPath } from 'node:url';
 
-import { router } from './router.js';
+import { router as defaultRouter } from './router.js';
 
 const PORT = Number(process.env.PORT || 3456);
 
-function createApp() {
+function createApp({ router = defaultRouter } = {}) {
   return http.createServer((req, res) => {
     Promise.resolve(router(req, res)).catch((error) => {
       console.error(error);
@@ -17,11 +17,13 @@ function createApp() {
 
 const server = createApp();
 
-function startServer(port = PORT) {
+function startServer(port = PORT, options) {
+  const app = options ? createApp(options) : server;
+
   return new Promise((resolve) => {
-    server.listen(port, () => {
+    app.listen(port, () => {
       console.log(`Listening on :${port}`);
-      resolve(server);
+      resolve(app);
     });
   });
 }

--- a/tasks/plans/277.md
+++ b/tasks/plans/277.md
@@ -1,0 +1,6 @@
+# Ticket 277 plan
+- Inspect current server/router/db layout.
+- Add an injectable readiness route that uses a simple SQLite query.
+- Keep existing contact routes unchanged.
+- Add tests for healthy and degraded readiness responses using mocked DB objects.
+- Run `node --test src/**/*.test.js`.

--- a/tasks/reports/277.md
+++ b/tasks/reports/277.md
@@ -1,0 +1,17 @@
+# Ticket 277 report
+
+## Changes
+- Added `GET /readiness` in `src/router.js`.
+- Added `createRouter({ database })` injection seam for readiness tests.
+- Exported the default SQLite connection from `src/db.js`.
+- Allowed `createApp`/`startServer` to accept an injected router in `src/server.js`.
+- Added `src/readiness.test.js` for healthy/degraded readiness checks.
+
+## Validation
+- `node --test src/**/*.test.js` ✅
+
+## Risk
+- Low. Routing change is additive; existing API lifecycle test still passes.
+
+## Rollback
+- Revert the readiness route and injection changes in `src/router.js`, `src/server.js`, `src/db.js`, and remove `src/readiness.test.js`.


### PR DESCRIPTION
## Summary
- add GET /readiness with a SQLite dependency check
- make router/server creation injectable so readiness can be tested with mocked DBs
- add healthy and degraded readiness tests while keeping the existing API lifecycle coverage

## Validation
- node --test src/**/*.test.js