### PR TITLE
feat: markdown-to-HTML preview tool

### DIFF
--- a/public/markdown.html
+++ b/public/markdown.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Markdown Preview</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5;
+      color: #333;
+      padding: 1rem;
+    }
+    h1 { text-align: center; margin-bottom: 1rem; color: #2c3e50; }
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      height: calc(100vh - 6rem);
+    }
+    .pane {
+      background: #fff;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .pane-header {
+      padding: 0.5rem 1rem;
+      background: #eee;
+      border-bottom: 1px solid #ddd;
+      font-weight: 600;
+      font-size: 0.9rem;
+      color: #555;
+    }
+    #editor {
+      flex: 1;
+      width: 100%;
+      border: none;
+      padding: 1rem;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      resize: none;
+      outline: none;
+      background: #fff;
+    }
+    #preview {
+      flex: 1;
+      padding: 1rem;
+      overflow-y: auto;
+      line-height: 1.6;
+    }
+    #preview h1, #preview h2, #preview h3,
+    #preview h4, #preview h5, #preview h6 {
+      margin: 0.8em 0 0.4em;
+      color: #2c3e50;
+    }
+    #preview h1 { font-size: 1.8em; border-bottom: 2px solid #eee; padding-bottom: 0.3em; }
+    #preview h2 { font-size: 1.4em; border-bottom: 1px solid #eee; padding-bottom: 0.2em; }
+    #preview p { margin: 0.6em 0; }
+    #preview code {
+      background: #f0f0f0;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+      font-size: 0.9em;
+    }
+    #preview pre {
+      background: #2d2d2d;
+      color: #f8f8f2;
+      padding: 1rem;
+      border-radius: 6px;
+      overflow-x: auto;
+      margin: 0.6em 0;
+    }
+    #preview pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+    #preview blockquote {
+      border-left: 4px solid #ddd;
+      padding: 0.5em 1em;
+      margin: 0.6em 0;
+      color: #666;
+      background: #f9f9f9;
+    }
+    #preview ul, #preview ol { margin: 0.6em 0; padding-left: 1.5em; }
+    #preview li { margin: 0.2em 0; }
+    #preview hr { border: none; border-top: 2px solid #eee; margin: 1em 0; }
+    #preview a { color: #3498db; }
+    #preview img { max-width: 100%; border-radius: 4px; }
+    .actions {
+      text-align: center;
+      margin-top: 0.5rem;
+    }
+    .actions button {
+      padding: 0.4rem 1rem;
+      margin: 0 0.3rem;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      background: #fff;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .actions button:hover { background: #eee; }
+    @media (max-width: 768px) {
+      .container { grid-template-columns: 1fr; height: auto; }
+      .pane { min-height: 40vh; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Markdown Preview</h1>
+  <div class="container">
+    <div class="pane">
+      <div class="pane-header">Markdown</div>
+      <textarea id="editor" placeholder="Type your markdown here..."># Hello World
+
+This is a **markdown** preview tool. Type on the left and see the *rendered HTML* on the right.
+
+## Features
+
+- Live preview as you type
+- Supports **bold**, *italic*, and `inline code`
+- Code blocks with syntax highlighting class
+- [Links](https://example.com) and images
+- Lists (ordered and unordered)
+- Blockquotes and horizontal rules
+
+## Code Example
+
+```js
+function greet(name) {
+  return `Hello, ${name}!`;
+}
+```
+
+> This is a blockquote spanning a line.
+
+---
+
+1. First item
+2. Second item
+3. Third item
+
+Enjoy writing markdown!</textarea>
+    </div>
+    <div class="pane">
+      <div class="pane-header">Preview</div>
+      <div id="preview"></div>
+    </div>
+  </div>
+  <div class="actions">
+    <button onclick="copyHtml()">Copy HTML</button>
+    <button onclick="clearEditor()">Clear</button>
+  </div>
+
+  <script>
+    const editor = document.getElementById('editor');
+    const preview = document.getElementById('preview');
+    let debounceTimer;
+
+    async function renderPreview() {
+      const markdown = editor.value;
+      try {
+        const res = await fetch('/api/markdown', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ markdown: markdown })
+        });
+        const data = await res.json();
+        if (data.html !== undefined) {
+          preview.innerHTML = data.html;
+        } else if (data.error) {
+          preview.innerHTML = '<p style="color:red">' + data.error + '</p>';
+        }
+      } catch (err) {
+        preview.innerHTML = '<p style="color:red">Error connecting to server</p>';
+      }
+    }
+
+    editor.addEventListener('input', function() {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(renderPreview, 200);
+    });
+
+    function copyHtml() {
+      var html = preview.innerHTML;
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(html).then(function() {
+          alert('HTML copied to clipboard!');
+        });
+      }
+    }
+
+    function clearEditor() {
+      editor.value = '';
+      preview.innerHTML = '';
+    }
+
+    renderPreview();
+  </script>
+</body>
+</html>

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -1,0 +1,141 @@
+/**
+ * Simple Markdown-to-HTML converter.
+ * Supports: headings, bold, italic, inline code, code blocks,
+ * links, images, unordered/ordered lists, blockquotes, hr, paragraphs.
+ */
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function processInline(text) {
+  let result = escapeHtml(text);
+
+  // Images: ![alt](src)
+  result = result.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">');
+
+  // Links: [text](url)
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+
+  // Bold: **text** or __text__
+  result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  result = result.replace(/__(.+?)__/g, '<strong>$1</strong>');
+
+  // Italic: *text* or _text_
+  result = result.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  result = result.replace(/(?<!\w)_(.+?)_(?!\w)/g, '<em>$1</em>');
+
+  // Inline code: `code`
+  result = result.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  return result;
+}
+
+export function markdownToHtml(markdown) {
+  if (typeof markdown !== 'string') {
+    throw new Error('Input must be a string');
+  }
+
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  const output = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block
+    if (line.startsWith('```')) {
+      const lang = line.slice(3).trim();
+      const codeLines = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        codeLines.push(escapeHtml(lines[i]));
+        i++;
+      }
+      i++; // skip closing ```
+      const langAttr = lang ? ` class="language-${escapeHtml(lang)}"` : '';
+      output.push(`<pre><code${langAttr}>${codeLines.join('\n')}</code></pre>`);
+      continue;
+    }
+
+    // Blank line
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      output.push(`<h${level}>${processInline(headingMatch[2])}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(line.trim())) {
+      output.push('<hr>');
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith('> ')) {
+      const quoteLines = [];
+      while (i < lines.length && lines[i].startsWith('> ')) {
+        quoteLines.push(lines[i].slice(2));
+        i++;
+      }
+      output.push(`<blockquote><p>${processInline(quoteLines.join(' '))}</p></blockquote>`);
+      continue;
+    }
+
+    // Unordered list
+    if (/^[-*+]\s+/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^[-*+]\s+/.test(lines[i])) {
+        items.push(processInline(lines[i].replace(/^[-*+]\s+/, '')));
+        i++;
+      }
+      output.push('<ul>' + items.map(item => `<li>${item}</li>`).join('') + '</ul>');
+      continue;
+    }
+
+    // Ordered list
+    if (/^\d+\.\s+/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+        items.push(processInline(lines[i].replace(/^\d+\.\s+/, '')));
+        i++;
+      }
+      output.push('<ol>' + items.map(item => `<li>${item}</li>`).join('') + '</ol>');
+      continue;
+    }
+
+    // Paragraph (collect consecutive non-blank lines that aren't other block elements)
+    const paraLines = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !lines[i].startsWith('#') &&
+      !lines[i].startsWith('```') &&
+      !lines[i].startsWith('> ') &&
+      !/^[-*+]\s+/.test(lines[i]) &&
+      !/^\d+\.\s+/.test(lines[i]) &&
+      !/^(-{3,}|\*{3,}|_{3,})$/.test(lines[i].trim())
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      output.push(`<p>${processInline(paraLines.join(' '))}</p>`);
+    }
+  }
+
+  return output.join('\n');
+}

--- a/src/markdown.test.js
+++ b/src/markdown.test.js
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { markdownToHtml } from './markdown.js';
+
+describe('markdownToHtml', () => {
+  it('converts headings', () => {
+    assert.equal(markdownToHtml('# Hello'), '<h1>Hello</h1>');
+    assert.equal(markdownToHtml('## World'), '<h2>World</h2>');
+    assert.equal(markdownToHtml('### Three'), '<h3>Three</h3>');
+    assert.equal(markdownToHtml('###### Six'), '<h6>Six</h6>');
+  });
+
+  it('converts bold text', () => {
+    assert.equal(markdownToHtml('**bold**'), '<p><strong>bold</strong></p>');
+    assert.equal(markdownToHtml('__bold__'), '<p><strong>bold</strong></p>');
+  });
+
+  it('converts italic text', () => {
+    assert.equal(markdownToHtml('*italic*'), '<p><em>italic</em></p>');
+    assert.equal(markdownToHtml('_italic_'), '<p><em>italic</em></p>');
+  });
+
+  it('converts inline code', () => {
+    assert.equal(markdownToHtml('use `console.log`'), '<p>use <code>console.log</code></p>');
+  });
+
+  it('converts code blocks', () => {
+    const md = '```js\nconst x = 1;\n```';
+    const html = markdownToHtml(md);
+    assert.ok(html.includes('<pre><code class="language-js">'));
+    assert.ok(html.includes('const x = 1;'));
+  });
+
+  it('converts links', () => {
+    const html = markdownToHtml('[Google](https://google.com)');
+    assert.ok(html.includes('<a href="https://google.com">Google</a>'));
+  });
+
+  it('converts images', () => {
+    const html = markdownToHtml('![alt](pic.png)');
+    assert.ok(html.includes('<img src="pic.png" alt="alt">'));
+  });
+
+  it('converts unordered lists', () => {
+    const md = '- one\n- two\n- three';
+    const html = markdownToHtml(md);
+    assert.ok(html.includes('<ul>'));
+    assert.ok(html.includes('<li>one</li>'));
+    assert.ok(html.includes('<li>two</li>'));
+    assert.ok(html.includes('<li>three</li>'));
+  });
+
+  it('converts ordered lists', () => {
+    const md = '1. first\n2. second';
+    const html = markdownToHtml(md);
+    assert.ok(html.includes('<ol>'));
+    assert.ok(html.includes('<li>first</li>'));
+    assert.ok(html.includes('<li>second</li>'));
+  });
+
+  it('converts blockquotes', () => {
+    const html = markdownToHtml('> quoted text');
+    assert.ok(html.includes('<blockquote>'));
+    assert.ok(html.includes('quoted text'));
+  });
+
+  it('converts horizontal rules', () => {
+    assert.ok(markdownToHtml('---').includes('<hr>'));
+    assert.ok(markdownToHtml('***').includes('<hr>'));
+    assert.ok(markdownToHtml('___').includes('<hr>'));
+  });
+
+  it('converts paragraphs', () => {
+    assert.equal(markdownToHtml('Hello world'), '<p>Hello world</p>');
+  });
+
+  it('handles multiple paragraphs', () => {
+    const md = 'First para\n\nSecond para';
+    const html = markdownToHtml(md);
+    assert.ok(html.includes('<p>First para</p>'));
+    assert.ok(html.includes('<p>Second para</p>'));
+  });
+
+  it('escapes HTML in input', () => {
+    const html = markdownToHtml('<script>alert("xss")</script>');
+    assert.ok(!html.includes('<script>'));
+    assert.ok(html.includes('&lt;script&gt;'));
+  });
+
+  it('throws on non-string input', () => {
+    assert.throws(() => markdownToHtml(42), { message: 'Input must be a string' });
+    assert.throws(() => markdownToHtml(null), { message: 'Input must be a string' });
+  });
+
+  it('handles empty string', () => {
+    assert.equal(markdownToHtml(''), '');
+  });
+});
+
+describe('POST /api/markdown', () => {
+  let server;
+  let baseUrl;
+
+  it('setup server', async () => {
+    const { createApp } = await import('./server.js');
+    server = createApp();
+    await new Promise((resolve) => {
+      server.listen(0, () => {
+        const addr = server.address();
+        baseUrl = `http://localhost:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  it('returns 200 with HTML for valid markdown', async () => {
+    const res = await fetch(`${baseUrl}/api/markdown`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ markdown: '# Test' }),
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.html, '<h1>Test</h1>');
+  });
+
+  it('returns 400 when markdown field is missing', async () => {
+    const res = await fetch(`${baseUrl}/api/markdown`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+    const data = await res.json();
+    assert.ok(data.error.includes('markdown'));
+  });
+
+  it('returns 405 for GET', async () => {
+    const res = await fetch(`${baseUrl}/api/markdown`);
+    assert.equal(res.status, 405);
+  });
+
+  it('serves markdown preview page', async () => {
+    const res = await fetch(`${baseUrl}/markdown`);
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    assert.ok(text.includes('Markdown Preview'));
+  });
+
+  it('cleanup server', async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+});

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { create, deleteById, getAll, getById, update } from './db.js';
+import { markdownToHtml } from './markdown.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const publicDir = path.join(__dirname, '..', 'public');
 
 function sendJson(res, statusCode, payload) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
@@ -11,6 +19,28 @@ function sendMethodNotAllowed(res) {
 
 function sendNotFound(res) {
   sendJson(res, 404, { error: 'Not Found' });
+}
+
+function serveStaticFile(res, filePath) {
+  const ext = path.extname(filePath);
+  const contentTypes = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.svg': 'image/svg+xml',
+  };
+  const contentType = contentTypes[ext] || 'application/octet-stream';
+
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  } catch {
+    sendNotFound(res);
+  }
 }
 
 async function readJsonBody(req) {
@@ -48,6 +78,7 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    // Health endpoint
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);
@@ -56,6 +87,31 @@ export async function router(req, res) {
       return sendJson(res, 200, { status: 'ok' });
     }
 
+    // Markdown preview API
+    if (pathname === '/api/markdown') {
+      if (method !== 'POST') {
+        return sendMethodNotAllowed(res);
+      }
+
+      const body = await readJsonBody(req);
+
+      if (typeof body.markdown !== 'string') {
+        return sendJson(res, 400, { error: 'markdown field is required and must be a string' });
+      }
+
+      const html = markdownToHtml(body.markdown);
+      return sendJson(res, 200, { html });
+    }
+
+    // Markdown preview page
+    if (pathname === '/markdown' || pathname === '/markdown.html') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+      return serveStaticFile(res, path.join(publicDir, 'markdown.html'));
+    }
+
+    // Contacts API
     if (pathname === '/api/contacts') {
       if (method === 'GET') {
         return sendJson(res, 200, getAll());


### PR DESCRIPTION
## Summary

Adds a markdown-to-HTML preview tool with live editing, conversion API, and full test coverage.

## What was built

- **`src/markdown.js`** — Pure JS markdown-to-HTML converter supporting headings, bold, italic, code blocks, inline code, links, images, lists, blockquotes, horizontal rules, and paragraphs
- **`src/router.js`** — Updated with `POST /api/markdown` (JSON conversion endpoint) and `GET /markdown` (serves the editor UI)
- **`public/markdown.html`** — Split-pane editor with live preview, copy-to-clipboard for generated HTML
- **`src/markdown.test.js`** — 22 new tests (23 total including existing), all passing

## Testing

All 23 tests pass (`node --test`).

Resolves #281