### PR TITLE
[E2E-C-R2] feat(build-info): add GET /build-info endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^12.8.0"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-test-app",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "node src/server.js",

--- a/src/build-info.test.js
+++ b/src/build-info.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dbPath = path.resolve(__dirname, '..', 'data', 'contacts.db');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  fs.rmSync(dbPath, { force: true });
+
+  const { startServer } = await import('./server.js');
+  server = await startServer(0);
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  fs.rmSync(dbPath, { force: true });
+});
+
+test('GET /build-info returns build information', async () => {
+  const response = await fetch(`${baseUrl}/build-info`);
+
+  assert.equal(response.status, 200);
+  assert.ok(response.headers.get('content-type').includes('application/json'));
+
+  const body = await response.json();
+
+  assert.equal(typeof body.version, 'string');
+  assert.equal(typeof body.nodeVersion, 'string');
+  assert.equal(typeof body.platform, 'string');
+  assert.equal(typeof body.arch, 'string');
+  assert.equal(typeof body.uptime, 'number');
+  assert.equal(typeof body.timestamp, 'string');
+
+  assert.equal(body.version, pkg.version);
+  assert.equal(body.nodeVersion, process.version);
+});

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,9 @@
+import { createRequire } from 'node:module';
+
 import { create, deleteById, getAll, getById, update } from './db.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
 
 function sendJson(res, statusCode, payload) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
@@ -48,6 +53,21 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    if (pathname === '/build-info') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, {
+        version,
+        nodeVersion: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        uptime: process.uptime(),
+        timestamp: new Date().toISOString(),
+      });
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);


### PR DESCRIPTION
## Summary

Adds a `GET /build-info` observability probe endpoint for the Forge delivery pipeline (Track C Run 2).

## Changes

- `src/router.js` — added `GET /build-info` route returning version and runtime metadata
- `src/build-info.test.js` — new test file covering all acceptance criteria
- `package.json` — version set to `1.0.0`
- `package-lock.json` — lockfile sync

## Response Shape

```json
{
  "version": "1.0.0",
  "nodeVersion": "v22.x.x",
  "platform": "linux",
  "arch": "x64",
  "uptime": 12.345,
  "timestamp": "2026-04-02T00:36:00.000Z"
}
```

## Tests

- `node --test src/build-info.test.js` → 1 passed ✅
- Pre-existing `api.test.js` SQLite readonly error pre-dates this PR (not caused by this work)

Ticket: #291