### PR TITLE
feat(statusz): add GET /statusz health endpoint

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -48,6 +48,14 @@ export async function router(req, res) {
   const { pathname } = url;
 
   try {
+    if (pathname === '/statusz') {
+      if (method !== 'GET') {
+        return sendMethodNotAllowed(res);
+      }
+
+      return sendJson(res, 200, { ok: true, service: 'oc-test-app' });
+    }
+
     if (pathname === '/api/health') {
       if (method !== 'GET') {
         return sendMethodNotAllowed(res);

--- a/src/statusz.test.js
+++ b/src/statusz.test.js
@@ -1,0 +1,20 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from './server.js';
+
+describe('GET /statusz', () => {
+  const server = createApp();
+
+  after(() => new Promise((resolve) => server.close(resolve)));
+
+  it('returns 200 with health payload', async () => {
+    await new Promise((resolve) => server.listen(0, resolve));
+    const { port } = server.address();
+
+    const res = await fetch(`http://127.0.0.1:${port}/statusz`);
+
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get('content-type').includes('application/json'));
+    assert.deepStrictEqual(await res.json(), { ok: true, service: 'oc-test-app' });
+  });
+});


### PR DESCRIPTION
Adds a GET /statusz health endpoint that returns `{ok: true, service: "oc-test-app"}`.

### Changes
- `src/router.js` — added GET /statusz route
- `src/statusz.test.js` — new focused test file

All tests pass (2/2).

Closes ticket-293.